### PR TITLE
Add utils tests

### DIFF
--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { parseSummaryToHumanReadable } from '$lib/utils'
+import { parseSummaryToHumanReadable, extractReplies, formatMessagesToRecentText } from '$lib/utils'
 import { describe, expect, it } from 'vitest'
 
 describe('parseSummaryToHumanReadable', () => {
@@ -38,5 +38,32 @@ Reply 1: First reply`
   it('should handle empty input', () => {
     const result = parseSummaryToHumanReadable('')
     expect(result).toBe('')
+  })
+})
+
+describe('extractReplies', () => {
+  it('parses replies with and without formatting', () => {
+    const raw = `**Reply 1:** "First reply"
+Reply 2: Second reply
+Reply 3: *Third reply*`
+
+    const replies = extractReplies(raw)
+
+    expect(replies[0]).toBe('First reply')
+    expect(replies[1]).toBe('Second reply')
+    expect(replies[2]).toContain('Third reply')
+  })
+})
+
+describe('formatMessagesToRecentText', () => {
+  it('formats messages with the correct tags', () => {
+    const messages = [
+      { sender: 'me', text: 'Hello', timestamp: '1' },
+      { sender: 'partner', text: 'Hi there', timestamp: '2' }
+    ]
+
+    const formatted = formatMessagesToRecentText(messages)
+
+    expect(formatted).toEqual(['Me: Hello', 'Partner: Hi there'])
   })
 })


### PR DESCRIPTION
## Summary
- extend `utils.test.ts` to test reply parsing and message formatting

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683f8e47050c832085a28e3b54bfdd0e