### PR TITLE
Fix navigation loop when changing lookBackHours

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -57,9 +57,8 @@ $effect(() => {
     if (lookBack) {
         const url = new URL(window.location.href)
         const current = url.searchParams.get('lookBackHours')
-        if (current === lookBack) {
-            return
-        }
+
+        if (current === lookBack) return
 
         // Update the URL with the new lookBackHours parameter
         url.searchParams.set('lookBackHours', lookBack)

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -55,8 +55,13 @@ $effect(() => {
 $effect(() => {
     const lookBack = formState.form.lookBackHours
     if (lookBack) {
-        // Update the URL with the new lookBackHours parameter
         const url = new URL(window.location.href)
+        const current = url.searchParams.get('lookBackHours')
+        if (current === lookBack) {
+            return
+        }
+
+        // Update the URL with the new lookBackHours parameter
         url.searchParams.set('lookBackHours', lookBack)
 
         // Use SvelteKit's goto to navigate to the new URL


### PR DESCRIPTION
## Summary
- avoid unnecessary page navigation when the selected lookBackHours matches the current URL

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find module './.svelte-kit/tsconfig.json')*

------
https://chatgpt.com/codex/tasks/task_e_684083e4d2888320a8e190457a63a1e4