### PR TITLE
Use SvelteKit form actions for summary generation

### DIFF
--- a/src/lib/components/AiProviderSelector.svelte
+++ b/src/lib/components/AiProviderSelector.svelte
@@ -4,7 +4,11 @@ let { value = $bindable('openai') }: { value: string } = $props()
 </script>
 
 <section>
-	<select id="ai-provider-select" bind:value>
+	<select 
+        id="ai-provider-select" 
+        name="provider" 
+        bind:value
+    >
 		<option value="openai">openai</option>
 		<option value="khoj">khoj</option>
 	</select>

--- a/src/lib/components/ControlBar.svelte
+++ b/src/lib/components/ControlBar.svelte
@@ -29,10 +29,14 @@ const lookBackOptions = [
 <section class="control-bar">
 	<div class="timeframe-controls">
 		<label for="window-back">summarize last:</label>
-		<select id="window-back" bind:value={lookBackHours}>
-			{#each lookBackOptions as option (option.value)}
-				<option value={option.value}>{option.label}</option>
-			{/each}
+		<select 
+		id="window-back" 
+		name="lookBackHours" 
+		bind:value={lookBackHours}
+	>
+		{#each lookBackOptions as option (option.value)}
+			<option value={option.value}>{option.label}</option>
+		{/each}
 		</select>
 		<button type="button" class="go-button" { onclick }  disabled={!canGenerate}>
 			{#if isLoading}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -22,48 +22,29 @@ export const load: PageServerLoad = async ({ url }) => {
 export const actions: Actions = {
     generate: async ({ request }) => {
         // Log request details
-        logger.debug({ 
+        logger.debug({
             method: request.method,
             url: request.url,
-            headers: Object.fromEntries(request.headers.entries()) 
+            headers: Object.fromEntries(request.headers.entries())
         }, 'Received request in action')
-        
+
         try {
-            // Check content type
             const contentType = request.headers.get('content-type') || ''
 
-            // Handle both form data and URL-encoded form data
             let context = ''
             let messagesString = ''
             let tone = DEFAULT_TONE
             let provider = DEFAULT_PROVIDER
 
-            if (contentType.includes('multipart/form-data') || contentType.includes('application/x-www-form-urlencoded')) {
-                const formData = await request.formData()
-                const formDataObj = Object.fromEntries(formData.entries())
-                
-                messagesString = formData.get('messages') as string
-                tone = formData.get('tone') as string || DEFAULT_TONE
-                context = formData.get('context') as string || ''
-                provider = formData.get('provider') as string || DEFAULT_PROVIDER
-                
-                logger.debug({ formData: formDataObj }, 'Received form data in action')
-            } else {
-                // Try to parse as JSON
-                try {
-                    const data = await request.json()
-                    logger.debug({ data }, 'Received JSON data in action')
-                    messagesString = data.messages ? JSON.stringify(data.messages) : ''
-                    tone = data.tone || DEFAULT_TONE
-                    context = data.context || ''
-                    provider = data.provider || DEFAULT_PROVIDER
-                } catch (e) {
-                    return fail(400, {
-                        error: 'Unsupported Content-Type',
-                        details: 'Content-Type must be multipart/form-data, application/x-www-form-urlencoded, or application/json'
-                    })
-                }
-            }
+            const formData = await request.formData()
+            const formDataObj = Object.fromEntries(formData.entries())
+
+            messagesString = formData.get('messages') as string
+            tone = formData.get('tone') as string || DEFAULT_TONE
+            context = formData.get('context') as string || ''
+            provider = formData.get('provider') as string || DEFAULT_PROVIDER
+
+            logger.debug({ formData: formDataObj }, 'Received form data in action')
 
             if (!messagesString || !tone) {
                 return fail(400, { error: 'Invalid request format: Missing messages or tone.' })

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -21,6 +21,13 @@ export const load: PageServerLoad = async ({ url }) => {
 
 export const actions: Actions = {
     generate: async ({ request }) => {
+        // Log request details
+        logger.debug({ 
+            method: request.method,
+            url: request.url,
+            headers: Object.fromEntries(request.headers.entries()) 
+        }, 'Received request in action')
+        
         try {
             // Check content type
             const contentType = request.headers.get('content-type') || ''
@@ -33,14 +40,19 @@ export const actions: Actions = {
 
             if (contentType.includes('multipart/form-data') || contentType.includes('application/x-www-form-urlencoded')) {
                 const formData = await request.formData()
+                const formDataObj = Object.fromEntries(formData.entries())
+                
                 messagesString = formData.get('messages') as string
-                tone = formData.get('tone') as string
-                context = formData.get('context') as string
-                provider = formData.get('provider') as string
+                tone = formData.get('tone') as string || DEFAULT_TONE
+                context = formData.get('context') as string || ''
+                provider = formData.get('provider') as string || DEFAULT_PROVIDER
+                
+                logger.debug({ formData: formDataObj }, 'Received form data in action')
             } else {
                 // Try to parse as JSON
                 try {
                     const data = await request.json()
+                    logger.debug({ data }, 'Received JSON data in action')
                     messagesString = data.messages ? JSON.stringify(data.messages) : ''
                     tone = data.tone || DEFAULT_TONE
                     context = data.context || ''

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -21,16 +21,7 @@ export const load: PageServerLoad = async ({ url }) => {
 
 export const actions: Actions = {
     generate: async ({ request }) => {
-        // Log request details
-        logger.debug({
-            method: request.method,
-            url: request.url,
-            headers: Object.fromEntries(request.headers.entries())
-        }, 'Received request in action')
-
         try {
-            const contentType = request.headers.get('content-type') || ''
-
             let context = ''
             let messagesString = ''
             let tone = DEFAULT_TONE
@@ -44,7 +35,7 @@ export const actions: Actions = {
             context = formData.get('context') as string || ''
             provider = formData.get('provider') as string || DEFAULT_PROVIDER
 
-            logger.debug({ formData: formDataObj }, 'Received form data in action')
+            logger.debug({ formData: formDataObj }, 'Received form data')
 
             if (!messagesString || !tone) {
                 return fail(400, { error: 'Invalid request format: Missing messages or tone.' })
@@ -65,9 +56,8 @@ export const actions: Actions = {
             }
 
             const result = await getReplies(messages, tone, context || '')
-            logger.debug({ resultFromService: result }, 'Result received from AI service in action')
+            logger.debug({ resultFromService: result }, 'Result received from AI service')
 
-            // Return the result directly - SvelteKit will handle the JSON serialization
             return result
         } catch (err) {
             logger.error({ err }, 'Error generating suggestions')

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -104,9 +104,7 @@ type FormResult = {
     }
 }
 
-// The enhance function with proper typing
 const enhanceSubmit: import('@sveltejs/kit').SubmitFunction = () => {
-    // Set loading state immediately when form is submitted
     formState.ui.loading = true
     formState.form.summary = 'Generating summary and replies...'
     formState.form.suggestedReplies = []

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -106,12 +106,13 @@ type FormResult = {
 
 // The enhance function with proper typing
 const enhanceSubmit: import('@sveltejs/kit').SubmitFunction = () => {
+    // Set loading state immediately when form is submitted
+    formState.ui.loading = true
+    formState.form.summary = 'Generating summary and replies...'
+    formState.form.suggestedReplies = []
+
     // Return a function that will be called with the form submission result
     return async ({ result, update }) => {
-        formState.ui.loading = true
-        formState.form.summary = ''
-        formState.form.suggestedReplies = []
-
         try {
             // Handle the form submission result
             if (result.type === 'success' && result.data) {
@@ -130,9 +131,12 @@ const enhanceSubmit: import('@sveltejs/kit').SubmitFunction = () => {
             console.error('Error processing form submission:', error)
             formState.form.summary =
                 'An error occurred while processing the response.'
-            throw error
+            formState.form.suggestedReplies = []
         } finally {
-            formState.ui.loading = false
+            // Only set loading to false after a short delay to ensure UI updates are visible
+            setTimeout(() => {
+                formState.ui.loading = false
+            }, 100)
         }
     }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -159,6 +159,11 @@ function onclick() {
                     use:enhance={enhanceSubmit}
                     bind:this={formElement}
                 >
+                    <!-- Hidden fields to include in form submission -->
+                    <input type="hidden" name="messages" value={JSON.stringify(formState.form.messages)} />
+                    <input type="hidden" name="tone" value={formState.form.tone} />
+                    <input type="hidden" name="context" value={formState.form.additionalContext} />
+                    <input type="hidden" name="provider" value={formState.ai.provider} />
 
 			<ControlBar 
 				bind:lookBackHours={formState.form.lookBackHours}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -94,16 +94,6 @@ $effect(() => {
 // biome-ignore lint/style/useConst: assigned by Svelte via bind:this
 let formElement: HTMLFormElement | null = null
 
-// Type for the form submission result
-type FormResult = {
-    type: 'success' | 'failure' | 'error'
-    data?: {
-        summary: string
-        replies: string[]
-        error?: string
-    }
-}
-
 const enhanceSubmit: import('@sveltejs/kit').SubmitFunction = () => {
     formState.ui.loading = true
     formState.form.summary = 'Generating summary and replies...'


### PR DESCRIPTION
## Summary
- switch `/` page to use `<form action="?/generate">`
- add `use:enhance` handler updating form state with returned summary and replies
- remove old fetch and JSON parsing logic

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684098e4fc848320b648f291220eb910