### PR TITLE
Implement login form actions

### DIFF
--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,0 +1,59 @@
+import {
+    BASIC_AUTH_PASSWORD,
+    BASIC_AUTH_USERNAME,
+    JWT_SECRET,
+} from '$env/static/private'
+import { logger } from '$lib/logger'
+import type { Actions } from './$types'
+import { fail, redirect } from '@sveltejs/kit'
+import jwt from 'jsonwebtoken'
+
+const AUTH_COOKIE_MAX_AGE = 60 * 60 * 24 * 30
+
+export const actions: Actions = {
+    default: async ({ request, cookies, url }) => {
+        if (!JWT_SECRET) {
+            logger.error('JWT_SECRET is not defined. Cannot issue JWTs.')
+            return fail(500, { error: 'Server configuration error' })
+        }
+        try {
+            logger.debug(
+                '[LOGIN PAGE] Received POST request. URL:',
+                JSON.stringify(url),
+            )
+            const formData = await request.formData()
+            const username = formData.get('username')
+            const password = formData.get('password')
+
+            if (
+                username === BASIC_AUTH_USERNAME &&
+                password === BASIC_AUTH_PASSWORD
+            ) {
+                const cookieOptions = {
+                    path: '/' as const,
+                    httpOnly: true,
+                    secure: true,
+                    sameSite: 'strict' as const,
+                    maxAge: AUTH_COOKIE_MAX_AGE,
+                }
+                const expiresIn = AUTH_COOKIE_MAX_AGE
+                const tokenPayload = {
+                    sub: username,
+                    iat: Math.floor(Date.now() / 1000),
+                    exp: Math.floor(Date.now() / 1000) + expiresIn,
+                }
+                const token = jwt.sign(tokenPayload, JWT_SECRET, {
+                    algorithm: 'HS256',
+                })
+                cookies.set('auth_token', token, cookieOptions)
+                throw redirect(302, '/')
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 1000))
+            return fail(401, { error: 'Invalid username or password' })
+        } catch (error) {
+            logger.error('[LOGIN PAGE] Login error:', error)
+            return fail(500, { error: 'Internal server error' })
+        }
+    },
+}

--- a/tests/routes/login/page.test.ts
+++ b/tests/routes/login/page.test.ts
@@ -2,157 +2,147 @@ import { describe, expect, it, vi } from 'vitest'
 
 // Create a mock login page model for testing
 interface FormState {
-  username: string
-  password: string
-  error: string
-  loading: boolean
+    username: string
+    password: string
+    error: string
+    loading: boolean
 }
 
 class LoginPageModel {
-  formState: FormState = {
-    username: '',
-    password: '',
-    error: '',
-    loading: false,
-  }
-  redirected = false
-  fetchCalled = false
-  fetchUrl = ''
-  fetchOptions: Record<string, unknown> = {}
-  navigationHelper = {
-    goto: (path: string) => { this.redirected = true; this.redirectPath = path }
-  }
-  redirectPath = ''
+    formState: FormState = {
+        username: '',
+        password: '',
+        error: '',
+        loading: false,
+    }
+    redirected = false
+    fetchCalled = false
+    fetchUrl = ''
+    fetchOptions: Record<string, unknown> = {}
+    navigationHelper = {
+        goto: (path: string) => {
+            this.redirected = true
+            this.redirectPath = path
+        },
+    }
+    redirectPath = ''
 
-  constructor(errorParam: string | null = null) {
-    // Simulate URL error param check
-    if (errorParam === 'too_many_attempts') {
-      this.formState.error = 'Too many login attempts. Please try again later.'
+    constructor(errorParam: string | null = null) {
+        // Simulate URL error param check
+        if (errorParam === 'too_many_attempts') {
+            this.formState.error =
+                'Too many login attempts. Please try again later.'
+        }
+
+        // Automatically check auth on init
+        this.checkAuthStatus()
     }
 
-    // Automatically check auth on init
-    this.checkAuthStatus()
-  }
+    async checkAuthStatus(mockAuthenticated = false) {
+        this.fetchCalled = true
+        this.fetchUrl = '/api/auth/check'
 
-  async checkAuthStatus(mockAuthenticated = false) {
-    this.fetchCalled = true
-    this.fetchUrl = '/api/auth/check'
-
-    if (mockAuthenticated) {
-      this.navigationHelper.goto('/')
-    }
-  }
-
-  async handleSubmit(mockSuccess = false, mockError = false) {
-    this.formState.loading = true
-    this.formState.error = ''
-    this.fetchCalled = true
-    this.fetchUrl = '/api/auth/login'
-    this.fetchOptions = {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        username: this.formState.username,
-        password: this.formState.password
-      })
+        if (mockAuthenticated) {
+            this.navigationHelper.goto('/')
+        }
     }
 
-    try {
-      if (mockError) {
-        throw new Error('Network error')
-      }
+    async handleSubmit(mockSuccess = false, mockError = false) {
+        this.formState.loading = true
+        this.formState.error = ''
 
-      if (mockSuccess) {
-        this.navigationHelper.goto('/')
-      } else {
-        this.formState.error = 'Invalid username or password'
-      }
-    } catch (error) {
-      this.formState.error = 'An error occurred during login'
-    } finally {
-      this.formState.loading = false
+        try {
+            if (mockError) {
+                throw new Error('Network error')
+            }
+
+            if (mockSuccess) {
+                this.navigationHelper.goto('/')
+            } else {
+                this.formState.error = 'Invalid username or password'
+            }
+        } catch (error) {
+            this.formState.error = 'An error occurred during login'
+        } finally {
+            this.formState.loading = false
+        }
     }
-  }
 
-  setUsername(username: string) {
-    this.formState.username = username
-  }
+    setUsername(username: string) {
+        this.formState.username = username
+    }
 
-  setPassword(password: string) {
-    this.formState.password = password
-  }
+    setPassword(password: string) {
+        this.formState.password = password
+    }
 }
 
 describe('Login Page Model', () => {
-  it('should initialize with empty form state', () => {
-    const loginPage = new LoginPageModel()
+    it('should initialize with empty form state', () => {
+        const loginPage = new LoginPageModel()
 
-    expect(loginPage.formState.username).toBe('')
-    expect(loginPage.formState.password).toBe('')
-    expect(loginPage.formState.error).toBe('')
-    expect(loginPage.formState.loading).toBe(false)
-  })
+        expect(loginPage.formState.username).toBe('')
+        expect(loginPage.formState.password).toBe('')
+        expect(loginPage.formState.error).toBe('')
+        expect(loginPage.formState.loading).toBe(false)
+    })
 
-  it('should show error message when error parameter is present', () => {
-    const loginPage = new LoginPageModel('too_many_attempts')
+    it('should show error message when error parameter is present', () => {
+        const loginPage = new LoginPageModel('too_many_attempts')
 
-    expect(loginPage.formState.error).toBe('Too many login attempts. Please try again later.')
-  })
+        expect(loginPage.formState.error).toBe(
+            'Too many login attempts. Please try again later.',
+        )
+    })
 
-  it('should check auth status on initialization', () => {
-    const loginPage = new LoginPageModel()
+    it('should check auth status on initialization', () => {
+        const loginPage = new LoginPageModel()
 
-    expect(loginPage.fetchCalled).toBe(true)
-    expect(loginPage.fetchUrl).toBe('/api/auth/check')
-  })
+        expect(loginPage.fetchCalled).toBe(true)
+        expect(loginPage.fetchUrl).toBe('/api/auth/check')
+    })
 
-  it('should redirect if already authenticated', async () => {
-    const loginPage = new LoginPageModel()
-    await loginPage.checkAuthStatus(true)
+    it('should redirect if already authenticated', async () => {
+        const loginPage = new LoginPageModel()
+        await loginPage.checkAuthStatus(true)
 
-    expect(loginPage.redirected).toBe(true)
-    expect(loginPage.redirectPath).toBe('/')
-  })
+        expect(loginPage.redirected).toBe(true)
+        expect(loginPage.redirectPath).toBe('/')
+    })
 
-  it('should handle form submission with successful login', async () => {
-    const loginPage = new LoginPageModel()
-    loginPage.setUsername('test_user')
-    loginPage.setPassword('correct_password')
+    it('should handle form submission with successful login', async () => {
+        const loginPage = new LoginPageModel()
+        loginPage.setUsername('test_user')
+        loginPage.setPassword('correct_password')
 
-    await loginPage.handleSubmit(true)
+        await loginPage.handleSubmit(true)
 
-    expect(loginPage.fetchCalled).toBe(true)
-    expect(loginPage.fetchUrl).toBe('/api/auth/login')
-    expect(loginPage.fetchOptions.method).toBe('POST')
-    expect(loginPage.redirected).toBe(true)
-    expect(loginPage.redirectPath).toBe('/')
-    expect(loginPage.formState.loading).toBe(false)
-  })
+        expect(loginPage.redirected).toBe(true)
+        expect(loginPage.redirectPath).toBe('/')
+        expect(loginPage.formState.loading).toBe(false)
+    })
 
-  it('should display error with failed login', async () => {
-    const loginPage = new LoginPageModel()
-    loginPage.setUsername('wrong_user')
-    loginPage.setPassword('wrong_password')
+    it('should display error with failed login', async () => {
+        const loginPage = new LoginPageModel()
+        loginPage.setUsername('wrong_user')
+        loginPage.setPassword('wrong_password')
 
-    await loginPage.handleSubmit(false)
+        await loginPage.handleSubmit(false)
 
-    expect(loginPage.fetchCalled).toBe(true)
-    expect(loginPage.fetchUrl).toBe('/api/auth/login')
-    expect(loginPage.formState.error).toBe('Invalid username or password')
-    expect(loginPage.redirected).toBe(false)
-    expect(loginPage.formState.loading).toBe(false)
-  })
+        expect(loginPage.formState.error).toBe('Invalid username or password')
+        expect(loginPage.redirected).toBe(false)
+        expect(loginPage.formState.loading).toBe(false)
+    })
 
-  it('should handle unexpected errors during login', async () => {
-    const loginPage = new LoginPageModel()
-    loginPage.setUsername('test_user')
-    loginPage.setPassword('test_password')
+    it('should handle unexpected errors during login', async () => {
+        const loginPage = new LoginPageModel()
+        loginPage.setUsername('test_user')
+        loginPage.setPassword('test_password')
 
-    await loginPage.handleSubmit(false, true)
+        await loginPage.handleSubmit(false, true)
 
-    expect(loginPage.fetchCalled).toBe(true)
-    expect(loginPage.formState.error).toBe('An error occurred during login')
-    expect(loginPage.redirected).toBe(false)
-    expect(loginPage.formState.loading).toBe(false)
-  })
+        expect(loginPage.formState.error).toBe('An error occurred during login')
+        expect(loginPage.redirected).toBe(false)
+        expect(loginPage.formState.loading).toBe(false)
+    })
 })


### PR DESCRIPTION
## Summary
- move login submission logic to a new server action
- switch login page to `<form>` enhanced with `use:enhance`
- update login tests for the form-action workflow

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684098f02e6c8320947bd739d91ccf7f