### PR TITLE
Store provider and tone in URL

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,8 @@ export interface MessageRow {
 
 export interface PageData {
     messages?: Message[]
+    tone?: ToneType
+    provider?: string
 }
 
 export type ToneType = 'gentle' | 'funny' | 'reassuring' | 'concise'

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -2,7 +2,7 @@ import { queryMessagesDb } from '$lib/iMessages'
 import { getKhojReply } from '$lib/khoj'
 import { logger } from '$lib/logger'
 import { getOpenaiReply } from '$lib/openAi'
-import type { Message } from '$lib/types'
+import type { Message, ToneType } from '$lib/types'
 import { fail } from '@sveltejs/kit'
 import type { Actions, PageServerLoad } from './$types'
 
@@ -12,11 +12,14 @@ const ONE_HOUR = 60 * 60 * 1000
 
 export const load: PageServerLoad = async ({ url }) => {
     const lookBack = Number.parseInt(url.searchParams.get('lookBackHours') || '1')
+    const tone = (url.searchParams.get('tone') || DEFAULT_TONE) as ToneType
+    const provider = url.searchParams.get('provider') || DEFAULT_PROVIDER
+
     const end = new Date()
     const start = new Date(end.getTime() - lookBack * ONE_HOUR)
     const { messages } = await queryMessagesDb(start.toISOString(), end.toISOString())
 
-    return { messages }
+    return { messages, tone, provider }
 }
 
 export const actions: Actions = {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms'
 import { goto } from '$app/navigation'
+import { browser } from '$app/environment'
 import AdditionalContext from '$lib/components/AdditionalContext.svelte'
 import AiProviderSelector from '$lib/components/AiProviderSelector.svelte'
 import ControlBar from '$lib/components/ControlBar.svelte'
@@ -16,7 +17,7 @@ const { data } = $props<{ data: PageData }>()
 
 const formState = $state({
     ai: {
-        provider: DEFAULT_PROVIDER,
+        provider: data?.provider ?? DEFAULT_PROVIDER,
     },
     ui: {
         loading: false,
@@ -25,7 +26,7 @@ const formState = $state({
     form: {
         lookBackHours: '1',
         additionalContext: '',
-        tone: 'gentle' as ToneType,
+        tone: (data?.tone ?? 'gentle') as ToneType,
         messages: [] as Message[],
         summary: '',
         suggestedReplies: [] as string[],
@@ -50,16 +51,11 @@ $effect(() => {
     if (data?.messages && Array.isArray(data.messages)) {
         formState.form.messages = data.messages
     }
-    if (data?.tone) {
-        formState.form.tone = data.tone
-    }
-    if (data?.provider) {
-        formState.ai.provider = data.provider
-    }
 })
 
 // Watch for changes to lookBackHours and navigate to the new URL
 $effect(() => {
+    if (!browser) return
     const lookBack = formState.form.lookBackHours
     if (lookBack) {
         const url = new URL(window.location.href)
@@ -77,6 +73,7 @@ $effect(() => {
 })
 
 $effect(() => {
+    if (!browser) return
     const tone = formState.form.tone
     if (tone) {
         const url = new URL(window.location.href)
@@ -90,6 +87,7 @@ $effect(() => {
 })
 
 $effect(() => {
+    if (!browser) return
     const provider = formState.ai.provider
     if (provider) {
         const url = new URL(window.location.href)
@@ -103,6 +101,7 @@ $effect(() => {
 })
 
 $effect(() => {
+    if (!browser) return
     const storedContext = localStorage.getItem(LOCAL_STORAGE_CONTEXT_KEY)
     if (storedContext) {
         formState.form.additionalContext = storedContext
@@ -113,6 +112,7 @@ $effect(() => {
 })
 
 $effect(() => {
+    if (!browser) return
     if (formState.form.additionalContext) {
         localStorage.setItem(
             LOCAL_STORAGE_CONTEXT_KEY,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -50,6 +50,12 @@ $effect(() => {
     if (data?.messages && Array.isArray(data.messages)) {
         formState.form.messages = data.messages
     }
+    if (data?.tone) {
+        formState.form.tone = data.tone
+    }
+    if (data?.provider) {
+        formState.ai.provider = data.provider
+    }
 })
 
 // Watch for changes to lookBackHours and navigate to the new URL
@@ -66,6 +72,32 @@ $effect(() => {
 
         // Use SvelteKit's goto to navigate to the new URL
         // This will trigger a new page load with the updated parameter
+        goto(url.toString(), { keepFocus: true, noScroll: true })
+    }
+})
+
+$effect(() => {
+    const tone = formState.form.tone
+    if (tone) {
+        const url = new URL(window.location.href)
+        const current = url.searchParams.get('tone')
+
+        if (current === tone) return
+
+        url.searchParams.set('tone', tone)
+        goto(url.toString(), { keepFocus: true, noScroll: true })
+    }
+})
+
+$effect(() => {
+    const provider = formState.ai.provider
+    if (provider) {
+        const url = new URL(window.location.href)
+        const current = url.searchParams.get('provider')
+
+        if (current === provider) return
+
+        url.searchParams.set('provider', provider)
         goto(url.toString(), { keepFocus: true, noScroll: true })
     }
 })

--- a/tests/routes/root/server.test.ts
+++ b/tests/routes/root/server.test.ts
@@ -43,11 +43,15 @@ describe('root page server', () => {
     vi.resetAllMocks()
   })
 
-  it('load should return messages', async () => {
+  it('load should return messages and query params', async () => {
     vi.mocked(queryDb.queryMessagesDb).mockResolvedValue({ messages: [{ text: 'hi', sender: 'partner', timestamp: '2025-01-01T00:00:00Z' }] })
-    const event = createMockRequestEvent(new URL('https://example.com/'))
+    const event = createMockRequestEvent(new URL('https://example.com/?tone=funny&provider=khoj'))
     const data = await serverModule.load(event as unknown as Parameters<typeof serverModule.load>[0])
-    expect(data).toEqual({ messages: [{ text: 'hi', sender: 'partner', timestamp: '2025-01-01T00:00:00Z' }] })
+    expect(data).toEqual({
+      messages: [{ text: 'hi', sender: 'partner', timestamp: '2025-01-01T00:00:00Z' }],
+      tone: 'funny',
+      provider: 'khoj'
+    })
   })
 
   it('generate action should return suggestions', async () => {


### PR DESCRIPTION
## Summary
- extend `PageData` to track `provider` and `tone`
- read `provider` and `tone` query params in page server load function
- sync form state from `PageData` and persist provider/tone to the URL
- update server tests for new return values

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6840be8f9dc0832094b7e51e1ed3931c