### PR TITLE
Fix duplicate test names in openAi suite

### DIFF
--- a/tests/lib/openAi.test.ts
+++ b/tests/lib/openAi.test.ts
@@ -75,7 +75,7 @@ Reply 3: "I'm looking forward to our hiking adventure! Do we need to get any new
     )
   })
 
-  it('should handle API errors gracefully', async () => {
+  it('should handle API errors gracefully with API key set', async () => {
     // Mock fetch to return an error
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,


### PR DESCRIPTION
## Summary
- rename one duplicate `"should handle API errors gracefully"` test
- confirm tests pass

## Testing
- `npx svelte-kit sync`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6841f4484104832082f7ad9a9a8206bd