### PR TITLE
Implement OpenAI function calling

### DIFF
--- a/tests/lib/openAi.test.ts
+++ b/tests/lib/openAi.test.ts
@@ -14,21 +14,11 @@ vi.mock('$env/static/private', async (importOriginal) => {
   }
 })
 
-// Mock '$lib/utils', providing specific mock for parseSummaryToHumanReadable
-// and using actual implementations for other functions.
-vi.mock('$lib/utils', async (importOriginal) => {
-  const actual = await importOriginal() as typeof import('$lib/utils')
-  return {
-    ...actual, // Use actual implementations for functions like formatMessages, extractReplies
-    parseSummaryToHumanReadable: vi.fn((text: string) => text.split('Reply 1:')[0].trim()), // Keep specific mock for this one
-  }
-})
 
 describe('getOpenaiReply', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     vi.mocked(await import('$env/static/private')).OPENAI_API_KEY = 'test-api-key'
-    vi.mocked(await import('$lib/utils')).parseSummaryToHumanReadable.mockImplementation((text: string) => text.split('Reply 1:')[0].trim())
     // Mock the fetch function
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -36,13 +26,21 @@ describe('getOpenaiReply', () => {
         choices: [
           {
             message: {
-              content: `Here's a summary of the conversation:
-              
-The conversation is about planning a weekend trip. Your partner seems excited about going hiking.
-
-Reply 1: "I'm excited about the hiking trip too! What trails are you thinking about?"
-Reply 2: "The hiking sounds fun! Should we plan to bring a picnic lunch?"
-Reply 3: "I'm looking forward to our hiking adventure! Do we need to get any new gear?"`
+              tool_calls: [
+                {
+                  function: {
+                    name: 'draft_replies',
+                    arguments: JSON.stringify({
+                      summary: "Here's a summary of the conversation. The conversation is about planning a weekend trip. Your partner seems excited about going hiking.",
+                      replies: [
+                        "I'm excited about the hiking trip too! What trails are you thinking about?",
+                        "The hiking sounds fun! Should we plan to bring a picnic lunch?",
+                        "I'm looking forward to our hiking adventure! Do we need to get any new gear?"
+                      ]
+                    })
+                  }
+                }
+              ]
             }
           }
         ]
@@ -75,6 +73,9 @@ Reply 3: "I'm looking forward to our hiking adventure! Do we need to get any new
         body: expect.any(String)
       })
     )
+
+    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+    expect(body.tools[0].function.name).toBe('draft_replies')
   })
 
   it('should handle API errors gracefully with API key set', async () => {
@@ -110,20 +111,28 @@ Reply 3: "I'm looking forward to our hiking adventure! Do we need to get any new
   })
 
 
-  it('should correctly clean replies by removing asterisks and quotes', async () => {
-    // We need to mock the response to exactly match what the cleanReply function expects
-    // The current implementation has a subtle issue with nested quotes and asterisks
+  it('should correctly parse replies with special characters', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
         choices: [
           {
             message: {
-              content: `Summary goes here.
-              
-Reply 1: This reply has asterisks and quotes
-Reply 2: "This one has just quotes"
-Reply 3: *This one has just asterisks*`
+              tool_calls: [
+                {
+                  function: {
+                    name: 'draft_replies',
+                    arguments: JSON.stringify({
+                      summary: 'Summary goes here.',
+                      replies: [
+                        'This reply has asterisks and quotes',
+                        '"This one has just quotes"',
+                        '*This one has just asterisks*'
+                      ]
+                    })
+                  }
+                }
+              ]
             }
           }
         ]
@@ -136,10 +145,11 @@ Reply 3: *This one has just asterisks*`
 
     const result = await getOpenaiReply(messages, 'gentle', '')
 
-    expect(result.replies.length).toBe(3)
-    // Verify that our matcher can correctly extract the replies
-    expect(result.replies[0]).toContain('This reply has asterisks and quotes')
-    expect(result.replies[1]).toContain('This one has just quotes')
-    expect(result.replies[2]).toContain('This one has just asterisks')
+    expect(result.summary).toBe('Summary goes here.')
+    expect(result.replies).toEqual([
+      'This reply has asterisks and quotes',
+      '"This one has just quotes"',
+      '*This one has just asterisks*'
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- describe summary/replies JSON schema for OpenAI
- call OpenAI with `tools` and parse returned JSON
- update tests for new JSON response format

## Testing
- `npx svelte-kit sync`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684217e6edf8832088bfb57c13d28489