### PR TITLE
Support optional OpenAI parameters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ OPENAI_MODEL=gpt-4
 
 # Temperature - Between 0.0 (robotic or repetitive) and 1.0 (random or flippant)
 OPENAI_TEMPERATURE=0.5
+OPENAI_TOP_P= # Nucleus sampling parameter
+OPENAI_FREQUENCY_PENALTY= # Discourage repetition
+OPENAI_PRESENCE_PENALTY= # Encourage new topics
 
 # KHOJ
 KHOJ_API_URL=http://127.0.0.1:42110/api/chat

--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,10 @@ PARTNER_PHONE=your-partner-phone (eg. +1234567890)
 # OpenAI
 OPENAI_API_KEY=your-openai-api-key
 OPENAI_MODEL=gpt-4
-
-# Temperature - Between 0.0 (robotic or repetitive) and 1.0 (random or flippant)
-OPENAI_TEMPERATURE=0.5
-OPENAI_TOP_P= # Nucleus sampling parameter
-OPENAI_FREQUENCY_PENALTY= # Discourage repetition
-OPENAI_PRESENCE_PENALTY= # Encourage new topics
+OPENAI_TEMPERATURE=0.5 # Between 0.0 (robotic or repetitive) and 1.0 (random or flippant)
+OPENAI_TOP_P=0.9 # Between 0.0 (most likely) and 1.0 (most diverse)
+OPENAI_FREQUENCY_PENALTY=0.2 # Between 0.0 (no penalty) and 1.0 (strong penalty)
+OPENAI_PRESENCE_PENALTY=0.2 # Between 0.0 (no penalty) and 1.0 (strong penalty)
 
 # KHOJ
 KHOJ_API_URL=http://127.0.0.1:42110/api/chat

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Create a `.env` file in the root directory by copying the `.env.example` file (`
 OPENAI_API_KEY=your_openai_api_key
 OPENAI_MODEL=gpt-4  # or any other OpenAI model
 OPENAI_TEMPERATURE=0.5
+OPENAI_TOP_P=
+OPENAI_FREQUENCY_PENALTY=
+OPENAI_PRESENCE_PENALTY=
+
+The following optional variables help shape the tone of the AI's replies:
+
+- `OPENAI_TOP_P` – lets the responses be a little more adventurous
+- `OPENAI_FREQUENCY_PENALTY` – keeps the suggestions from repeating themselves
+- `OPENAI_PRESENCE_PENALTY` – nudges the AI to bring up fresh ideas
 
 # Local Khoj Server
 # If you happen to have a local Khoj server, set these variables.

--- a/biome.json
+++ b/biome.json
@@ -12,8 +12,9 @@
             ".next",
             ".turbo",
             "dist",
-            "build"
-            , ".svelte-kit"
+            "build",
+            "coverage",
+            ".svelte-kit"
         ]
     },
     "formatter": {

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -7,5 +7,8 @@ declare namespace App {
     OPENAI_API_KEY?: string
     OPENAI_MODEL?: string
     OPENAI_TEMPERATURE?: string
+    OPENAI_TOP_P?: string
+    OPENAI_FREQUENCY_PENALTY?: string
+    OPENAI_PRESENCE_PENALTY?: string
   }
 }

--- a/src/lib/openAi.ts
+++ b/src/lib/openAi.ts
@@ -1,4 +1,11 @@
-import { OPENAI_API_KEY, OPENAI_MODEL, OPENAI_TEMPERATURE } from '$env/static/private'
+import {
+    OPENAI_API_KEY,
+    OPENAI_MODEL,
+    OPENAI_TEMPERATURE,
+    OPENAI_TOP_P,
+    OPENAI_FREQUENCY_PENALTY,
+    OPENAI_PRESENCE_PENALTY,
+} from '$env/static/private'
 import { logger } from './logger'
 import { PERMANENT_CONTEXT, buildReplyPrompt } from './prompts'
 import type { Message } from './types'
@@ -6,6 +13,13 @@ import { formatMessages } from './utils'
 
 const openaiModel = OPENAI_MODEL || 'gpt-4'
 const openaiTemperature = Number.parseFloat(OPENAI_TEMPERATURE || '0.5')
+const openaiTopP = OPENAI_TOP_P ? Number.parseFloat(OPENAI_TOP_P) : undefined
+const openaiFrequencyPenalty = OPENAI_FREQUENCY_PENALTY
+    ? Number.parseFloat(OPENAI_FREQUENCY_PENALTY)
+    : undefined
+const openaiPresencePenalty = OPENAI_PRESENCE_PENALTY
+    ? Number.parseFloat(OPENAI_PRESENCE_PENALTY)
+    : undefined
 const openaiApiUrl = 'https://api.openai.com/v1/chat/completions'
 
 const summaryFunction = {
@@ -16,7 +30,10 @@ const summaryFunction = {
         parameters: {
             type: 'object',
             properties: {
-                summary: { type: 'string', description: 'Brief summary of the conversation' },
+                summary: {
+                    type: 'string',
+                    description: 'Brief summary of the conversation',
+                },
                 replies: {
                     type: 'array',
                     items: { type: 'string' },
@@ -29,13 +46,15 @@ const summaryFunction = {
 } as const
 
 if (!OPENAI_API_KEY)
-    logger.warn('⚠️ OPENAI_API_KEY is not set. OpenAI integration will not work.')
+    logger.warn(
+        '⚠️ OPENAI_API_KEY is not set. OpenAI integration will not work.',
+    )
 
 export const getOpenaiReply = async (
     messages: Message[],
     tone: string,
     context: string,
-): Promise<{ summary: string, replies: string[] }> => {
+): Promise<{ summary: string; replies: string[] }> => {
     if (!OPENAI_API_KEY)
         return {
             summary: 'OpenAI API key is not configured.',
@@ -52,17 +71,27 @@ export const getOpenaiReply = async (
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'Authorization': `Bearer ${OPENAI_API_KEY}`
+                Authorization: `Bearer ${OPENAI_API_KEY}`,
             },
             body: JSON.stringify({
                 model: openaiModel,
                 messages: [
                     { role: 'system', content: PERMANENT_CONTEXT },
-                    { role: 'user', content: prompt }
+                    { role: 'user', content: prompt },
                 ],
                 temperature: openaiTemperature,
+                ...(openaiTopP ? { top_p: openaiTopP } : {}),
+                ...(openaiFrequencyPenalty
+                    ? { frequency_penalty: openaiFrequencyPenalty }
+                    : {}),
+                ...(openaiPresencePenalty
+                    ? { presence_penalty: openaiPresencePenalty }
+                    : {}),
                 tools: [summaryFunction],
-                tool_choice: { type: 'function', function: { name: summaryFunction.function.name } },
+                tool_choice: {
+                    type: 'function',
+                    function: { name: summaryFunction.function.name },
+                },
             }),
         })
 
@@ -71,31 +100,48 @@ export const getOpenaiReply = async (
             throw new Error(`OpenAI API error: ${response.status}`)
         }
 
-        logger.debug({ status: response.status, statusText: response.statusText }, 'OpenAI API response status')
+        logger.debug(
+            { status: response.status, statusText: response.statusText },
+            'OpenAI API response status',
+        )
         const data = await response.json()
         logger.debug({ data }, 'OpenAI API raw data')
 
-        const args = data.choices?.[0]?.message?.tool_calls?.[0]?.function?.arguments || '{}'
+        const args =
+            data.choices?.[0]?.message?.tool_calls?.[0]?.function?.arguments ||
+            '{}'
         logger.debug({ args }, 'OpenAI API function arguments')
 
         let summary = ''
         let replies: string[] = []
         try {
-            const parsed = JSON.parse(args) as { summary?: string; replies?: string[] }
+            const parsed = JSON.parse(args) as {
+                summary?: string
+                replies?: string[]
+            }
             summary = parsed.summary || ''
             replies = parsed.replies || []
         } catch (parseErr) {
-            logger.error({ parseErr, args }, 'Failed to parse OpenAI function response')
+            logger.error(
+                { parseErr, args },
+                'Failed to parse OpenAI function response',
+            )
         }
 
-        logger.debug({ summary, replies }, 'Parsed summary and replies from OpenAI')
+        logger.debug(
+            { summary, replies },
+            'Parsed summary and replies from OpenAI',
+        )
 
         return { summary, replies }
     } catch (err) {
-        logger.error({ err }, 'Error in getOpenaiReply (fetching or parsing OpenAI response)')
+        logger.error(
+            { err },
+            'Error in getOpenaiReply (fetching or parsing OpenAI response)',
+        )
         return {
             summary: '',
-            replies: ['(Sorry, I had trouble generating a response.)']
+            replies: ['(Sorry, I had trouble generating a response.)'],
         }
     }
 }

--- a/src/lib/openAi.ts
+++ b/src/lib/openAi.ts
@@ -1,10 +1,5 @@
 import {
-    OPENAI_API_KEY,
-    OPENAI_MODEL,
-    OPENAI_TEMPERATURE,
-    OPENAI_TOP_P,
-    OPENAI_FREQUENCY_PENALTY,
-    OPENAI_PRESENCE_PENALTY,
+    OPENAI_API_KEY, OPENAI_FREQUENCY_PENALTY, OPENAI_MODEL, OPENAI_PRESENCE_PENALTY, OPENAI_TEMPERATURE, OPENAI_TOP_P,
 } from '$env/static/private'
 import { logger } from './logger'
 import { PERMANENT_CONTEXT, buildReplyPrompt } from './prompts'
@@ -46,9 +41,7 @@ const summaryFunction = {
 } as const
 
 if (!OPENAI_API_KEY)
-    logger.warn(
-        '⚠️ OPENAI_API_KEY is not set. OpenAI integration will not work.',
-    )
+    logger.warn('⚠️ OPENAI_API_KEY is not set. OpenAI integration will not work.')
 
 export const getOpenaiReply = async (
     messages: Message[],
@@ -81,12 +74,8 @@ export const getOpenaiReply = async (
                 ],
                 temperature: openaiTemperature,
                 ...(openaiTopP ? { top_p: openaiTopP } : {}),
-                ...(openaiFrequencyPenalty
-                    ? { frequency_penalty: openaiFrequencyPenalty }
-                    : {}),
-                ...(openaiPresencePenalty
-                    ? { presence_penalty: openaiPresencePenalty }
-                    : {}),
+                ...(openaiFrequencyPenalty ? { frequency_penalty: openaiFrequencyPenalty } : {}),
+                ...(openaiPresencePenalty ? { presence_penalty: openaiPresencePenalty } : {}),
                 tools: [summaryFunction],
                 tool_choice: {
                     type: 'function',
@@ -107,9 +96,7 @@ export const getOpenaiReply = async (
         const data = await response.json()
         logger.debug({ data }, 'OpenAI API raw data')
 
-        const args =
-            data.choices?.[0]?.message?.tool_calls?.[0]?.function?.arguments ||
-            '{}'
+        const args = data.choices?.[0]?.message?.tool_calls?.[0]?.function?.arguments || '{}'
         logger.debug({ args }, 'OpenAI API function arguments')
 
         let summary = ''
@@ -119,6 +106,7 @@ export const getOpenaiReply = async (
                 summary?: string
                 replies?: string[]
             }
+
             summary = parsed.summary || ''
             replies = parsed.replies || []
         } catch (parseErr) {
@@ -128,17 +116,11 @@ export const getOpenaiReply = async (
             )
         }
 
-        logger.debug(
-            { summary, replies },
-            'Parsed summary and replies from OpenAI',
-        )
+        logger.debug({ summary, replies }, 'Parsed summary and replies from OpenAI')
 
         return { summary, replies }
     } catch (err) {
-        logger.error(
-            { err },
-            'Error in getOpenaiReply (fetching or parsing OpenAI response)',
-        )
+        logger.error({ err }, 'Error in getOpenaiReply (fetching or parsing OpenAI response)')
         return {
             summary: '',
             replies: ['(Sorry, I had trouble generating a response.)'],

--- a/tests/lib/openAi.test.ts
+++ b/tests/lib/openAi.test.ts
@@ -4,152 +4,228 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock the environment variables
 vi.mock('$env/static/private', async (importOriginal) => {
-  const actual = await importOriginal() as Record<string, string | undefined>
-  return {
-    ...actual,
-    OPENAI_API_KEY: 'test-api-key',
-    OPENAI_MODEL: 'test-model',
-    OPENAI_TEMPERATURE: '0.5',
-    LOG_LEVEL: 'info'
-  }
+    const actual = (await importOriginal()) as Record<
+        string,
+        string | undefined
+    >
+    return {
+        ...actual,
+        OPENAI_API_KEY: 'test-api-key',
+        OPENAI_MODEL: 'test-model',
+        OPENAI_TEMPERATURE: '0.5',
+        OPENAI_TOP_P: '0.7',
+        OPENAI_FREQUENCY_PENALTY: '0.1',
+        OPENAI_PRESENCE_PENALTY: '0.2',
+        LOG_LEVEL: 'info',
+    }
 })
 
-
 describe('getOpenaiReply', () => {
-  beforeEach(async () => {
-    vi.clearAllMocks()
-    vi.mocked(await import('$env/static/private')).OPENAI_API_KEY = 'test-api-key'
-    // Mock the fetch function
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
-        choices: [
-          {
-            message: {
-              tool_calls: [
-                {
-                  function: {
-                    name: 'draft_replies',
-                    arguments: JSON.stringify({
-                      summary: "Here's a summary of the conversation. The conversation is about planning a weekend trip. Your partner seems excited about going hiking.",
-                      replies: [
-                        "I'm excited about the hiking trip too! What trails are you thinking about?",
-                        "The hiking sounds fun! Should we plan to bring a picnic lunch?",
-                        "I'm looking forward to our hiking adventure! Do we need to get any new gear?"
-                      ]
-                    })
-                  }
-                }
-              ]
-            }
-          }
+    beforeEach(async () => {
+        vi.clearAllMocks()
+        vi.mocked(await import('$env/static/private')).OPENAI_API_KEY =
+            'test-api-key'
+        // Mock the fetch function
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({
+                choices: [
+                    {
+                        message: {
+                            tool_calls: [
+                                {
+                                    function: {
+                                        name: 'draft_replies',
+                                        arguments: JSON.stringify({
+                                            summary:
+                                                "Here's a summary of the conversation. The conversation is about planning a weekend trip. Your partner seems excited about going hiking.",
+                                            replies: [
+                                                "I'm excited about the hiking trip too! What trails are you thinking about?",
+                                                'The hiking sounds fun! Should we plan to bring a picnic lunch?',
+                                                "I'm looking forward to our hiking adventure! Do we need to get any new gear?",
+                                            ],
+                                        }),
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }),
+        })
+    })
+
+    it('should return summary and replies when API call is successful', async () => {
+        const messages: Message[] = [
+            {
+                sender: 'partner',
+                text: "Let's go hiking this weekend!",
+                timestamp: '2025-05-23T12:00:00Z',
+            },
+            {
+                sender: 'me',
+                text: 'That sounds fun!',
+                timestamp: '2025-05-23T12:01:00Z',
+            },
         ]
-      })
-    })
-  })
 
-  it('should return summary and replies when API call is successful', async () => {
-    const messages: Message[] = [
-      { sender: 'partner', text: 'Let\'s go hiking this weekend!', timestamp: '2025-05-23T12:00:00Z' },
-      { sender: 'me', text: 'That sounds fun!', timestamp: '2025-05-23T12:01:00Z' }
-    ]
+        const result = await getOpenaiReply(messages, 'gentle', '')
 
-    const result = await getOpenaiReply(messages, 'gentle', '')
+        expect(result.summary).toBeTruthy()
+        expect(result.replies.length).toBe(3)
+        expect(result.replies[0]).toContain('excited about the hiking trip')
 
-    expect(result.summary).toBeTruthy()
-    expect(result.replies.length).toBe(3)
-    expect(result.replies[0]).toContain('excited about the hiking trip')
+        // Verify fetch was called with correct parameters
+        expect(global.fetch).toHaveBeenCalledTimes(1)
+        expect(global.fetch).toHaveBeenCalledWith(
+            'https://api.openai.com/v1/chat/completions',
+            expect.objectContaining({
+                method: 'POST',
+                headers: expect.objectContaining({
+                    'Content-Type': 'application/json',
+                    Authorization: 'Bearer test-api-key',
+                }),
+                body: expect.any(String),
+            }),
+        )
 
-    // Verify fetch was called with correct parameters
-    expect(global.fetch).toHaveBeenCalledTimes(1)
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://api.openai.com/v1/chat/completions',
-      expect.objectContaining({
-        method: 'POST',
-        headers: expect.objectContaining({
-          'Content-Type': 'application/json',
-          'Authorization': 'Bearer test-api-key'
-        }),
-        body: expect.any(String)
-      })
-    )
-
-    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
-    expect(body.tools[0].function.name).toBe('draft_replies')
-  })
-
-  it('should handle API errors gracefully with API key set', async () => {
-    // Mock fetch to return an error
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 500,
-      text: vi.fn().mockResolvedValue('Internal Server Error')
+        const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+        expect(body.tools[0].function.name).toBe('draft_replies')
     })
 
-    const messages: Message[] = [
-      { sender: 'partner', text: 'How are you today?', timestamp: '2025-05-23T12:00:00Z' }
-    ]
+    it('should handle API errors gracefully with API key set', async () => {
+        // Mock fetch to return an error
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            text: vi.fn().mockResolvedValue('Internal Server Error'),
+        })
 
-    const result = await getOpenaiReply(messages, 'gentle', '')
-
-    expect(result.summary).toBe('')
-    expect(result.replies).toEqual(['(Sorry, I had trouble generating a response.)'])
-  })
-
-  it('should handle case when OPENAI_API_KEY is not set', async () => {
-    // Mock the environment variables without the API key
-    vi.mocked(await import('$env/static/private')).OPENAI_API_KEY = ''
-
-    const messages: Message[] = [
-      { sender: 'partner', text: 'Hello!', timestamp: '2025-05-23T12:00:00Z' }
-    ]
-
-    const result = await getOpenaiReply(messages, 'gentle', '')
-
-    expect(result.summary).toBe('OpenAI API key is not configured.')
-    expect(result.replies).toEqual(['Please set up your OpenAI API key in the .env file.'])
-  })
-
-
-  it('should correctly parse replies with special characters', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
-        choices: [
-          {
-            message: {
-              tool_calls: [
-                {
-                  function: {
-                    name: 'draft_replies',
-                    arguments: JSON.stringify({
-                      summary: 'Summary goes here.',
-                      replies: [
-                        'This reply has asterisks and quotes',
-                        '"This one has just quotes"',
-                        '*This one has just asterisks*'
-                      ]
-                    })
-                  }
-                }
-              ]
-            }
-          }
+        const messages: Message[] = [
+            {
+                sender: 'partner',
+                text: 'How are you today?',
+                timestamp: '2025-05-23T12:00:00Z',
+            },
         ]
-      })
+
+        const result = await getOpenaiReply(messages, 'gentle', '')
+
+        expect(result.summary).toBe('')
+        expect(result.replies).toEqual([
+            '(Sorry, I had trouble generating a response.)',
+        ])
     })
 
-    const messages: Message[] = [
-      { sender: 'partner', text: 'Test message', timestamp: '2025-05-23T12:00:00Z' }
-    ]
+    it('should handle case when OPENAI_API_KEY is not set', async () => {
+        // Mock the environment variables without the API key
+        vi.mocked(await import('$env/static/private')).OPENAI_API_KEY = ''
 
-    const result = await getOpenaiReply(messages, 'gentle', '')
+        const messages: Message[] = [
+            {
+                sender: 'partner',
+                text: 'Hello!',
+                timestamp: '2025-05-23T12:00:00Z',
+            },
+        ]
 
-    expect(result.summary).toBe('Summary goes here.')
-    expect(result.replies).toEqual([
-      'This reply has asterisks and quotes',
-      '"This one has just quotes"',
-      '*This one has just asterisks*'
-    ])
-  })
+        const result = await getOpenaiReply(messages, 'gentle', '')
+
+        expect(result.summary).toBe('OpenAI API key is not configured.')
+        expect(result.replies).toEqual([
+            'Please set up your OpenAI API key in the .env file.',
+        ])
+    })
+
+    it('should correctly parse replies with special characters', async () => {
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({
+                choices: [
+                    {
+                        message: {
+                            tool_calls: [
+                                {
+                                    function: {
+                                        name: 'draft_replies',
+                                        arguments: JSON.stringify({
+                                            summary: 'Summary goes here.',
+                                            replies: [
+                                                'This reply has asterisks and quotes',
+                                                '"This one has just quotes"',
+                                                '*This one has just asterisks*',
+                                            ],
+                                        }),
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            }),
+        })
+
+        const messages: Message[] = [
+            {
+                sender: 'partner',
+                text: 'Test message',
+                timestamp: '2025-05-23T12:00:00Z',
+            },
+        ]
+
+        const result = await getOpenaiReply(messages, 'gentle', '')
+
+        expect(result.summary).toBe('Summary goes here.')
+        expect(result.replies).toEqual([
+            'This reply has asterisks and quotes',
+            '"This one has just quotes"',
+            '*This one has just asterisks*',
+        ])
+    })
+
+    it('includes optional parameters when environment variables are set', async () => {
+        const messages: Message[] = [
+            {
+                sender: 'partner',
+                text: 'Hello!',
+                timestamp: '2025-05-23T12:00:00Z',
+            },
+        ]
+
+        await getOpenaiReply(messages, 'gentle', '')
+
+        const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+        expect(body.top_p).toBe(0.7)
+        expect(body.frequency_penalty).toBe(0.1)
+        expect(body.presence_penalty).toBe(0.2)
+    })
+
+    it('omits optional parameters when environment variables are empty', async () => {
+        vi.mocked(await import('$env/static/private')).OPENAI_TOP_P = ''
+        vi.mocked(
+            await import('$env/static/private'),
+        ).OPENAI_FREQUENCY_PENALTY = ''
+        vi.mocked(await import('$env/static/private')).OPENAI_PRESENCE_PENALTY =
+            ''
+        vi.resetModules()
+        const { getOpenaiReply: getOpenaiReplyNoOpts } = await import(
+            '$lib/openAi'
+        )
+
+        const messages: Message[] = [
+            {
+                sender: 'partner',
+                text: 'Hi',
+                timestamp: '2025-05-23T12:00:00Z',
+            },
+        ]
+
+        await getOpenaiReplyNoOpts(messages, 'gentle', '')
+
+        const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
+        expect(body).not.toHaveProperty('top_p')
+        expect(body).not.toHaveProperty('frequency_penalty')
+        expect(body).not.toHaveProperty('presence_penalty')
+        expect(body).not.toHaveProperty('user')
+    })
 })

--- a/tests/lib/openAi.test.ts
+++ b/tests/lib/openAi.test.ts
@@ -1,231 +1,238 @@
 import { getOpenaiReply } from '$lib/openAi'
 import type { Message } from '$lib/types'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Helper function to get the request body from the fetch mock
+function getFetchRequestBody<T = unknown>(callIndex = 0): T {
+  const fetchMock = global.fetch as Mock
+  const fetchCall = fetchMock.mock.calls[callIndex][1] as RequestInit
+  return JSON.parse(fetchCall.body as string) as T
+}
 
 // Mock the environment variables
 vi.mock('$env/static/private', async (importOriginal) => {
-    const actual = (await importOriginal()) as Record<
-        string,
-        string | undefined
-    >
-    return {
-        ...actual,
-        OPENAI_API_KEY: 'test-api-key',
-        OPENAI_MODEL: 'test-model',
-        OPENAI_TEMPERATURE: '0.5',
-        OPENAI_TOP_P: '0.7',
-        OPENAI_FREQUENCY_PENALTY: '0.1',
-        OPENAI_PRESENCE_PENALTY: '0.2',
-        LOG_LEVEL: 'info',
-    }
+  const actual = (await importOriginal()) as Record<
+    string,
+    string | undefined
+  >
+  return {
+    ...actual,
+    OPENAI_API_KEY: 'test-api-key',
+    OPENAI_MODEL: 'test-model',
+    OPENAI_TEMPERATURE: '0.5',
+    OPENAI_TOP_P: '0.7',
+    OPENAI_FREQUENCY_PENALTY: '0.1',
+    OPENAI_PRESENCE_PENALTY: '0.2',
+    LOG_LEVEL: 'info',
+  }
 })
 
 describe('getOpenaiReply', () => {
-    beforeEach(async () => {
-        vi.clearAllMocks()
-        vi.mocked(await import('$env/static/private')).OPENAI_API_KEY =
-            'test-api-key'
-        // Mock the fetch function
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: vi.fn().mockResolvedValue({
-                choices: [
-                    {
-                        message: {
-                            tool_calls: [
-                                {
-                                    function: {
-                                        name: 'draft_replies',
-                                        arguments: JSON.stringify({
-                                            summary:
-                                                "Here's a summary of the conversation. The conversation is about planning a weekend trip. Your partner seems excited about going hiking.",
-                                            replies: [
-                                                "I'm excited about the hiking trip too! What trails are you thinking about?",
-                                                'The hiking sounds fun! Should we plan to bring a picnic lunch?',
-                                                "I'm looking forward to our hiking adventure! Do we need to get any new gear?",
-                                            ],
-                                        }),
-                                    },
-                                },
-                            ],
-                        },
-                    },
-                ],
-            }),
-        })
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.mocked(await import('$env/static/private')).OPENAI_API_KEY =
+      'test-api-key'
+    // Mock the fetch function
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  function: {
+                    name: 'draft_replies',
+                    arguments: JSON.stringify({
+                      summary:
+                        "Here's a summary of the conversation. The conversation is about planning a weekend trip. Your partner seems excited about going hiking.",
+                      replies: [
+                        "I'm excited about the hiking trip too! What trails are you thinking about?",
+                        'The hiking sounds fun! Should we plan to bring a picnic lunch?',
+                        "I'm looking forward to our hiking adventure! Do we need to get any new gear?",
+                      ],
+                    }),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    })
+  })
+
+  it('should return summary and replies when API call is successful', async () => {
+    const messages: Message[] = [
+      {
+        sender: 'partner',
+        text: "Let's go hiking this weekend!",
+        timestamp: '2025-05-23T12:00:00Z',
+      },
+      {
+        sender: 'me',
+        text: 'That sounds fun!',
+        timestamp: '2025-05-23T12:01:00Z',
+      },
+    ]
+
+    const result = await getOpenaiReply(messages, 'gentle', '')
+
+    expect(result.summary).toBeTruthy()
+    expect(result.replies.length).toBe(3)
+    expect(result.replies[0]).toContain('excited about the hiking trip')
+
+    // Verify fetch was called with correct parameters
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/chat/completions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-api-key',
+        }),
+        body: expect.any(String),
+      }),
+    )
+
+    const body = getFetchRequestBody<{ tools: Array<{ function: { name: string } }> }>()
+    expect(body.tools[0].function.name).toBe('draft_replies')
+  })
+
+  it('should handle API errors gracefully with API key set', async () => {
+    // Mock fetch to return an error
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue('Internal Server Error'),
     })
 
-    it('should return summary and replies when API call is successful', async () => {
-        const messages: Message[] = [
-            {
-                sender: 'partner',
-                text: "Let's go hiking this weekend!",
-                timestamp: '2025-05-23T12:00:00Z',
+    const messages: Message[] = [
+      {
+        sender: 'partner',
+        text: 'How are you today?',
+        timestamp: '2025-05-23T12:00:00Z',
+      },
+    ]
+
+    const result = await getOpenaiReply(messages, 'gentle', '')
+
+    expect(result.summary).toBe('')
+    expect(result.replies).toEqual([
+      '(Sorry, I had trouble generating a response.)',
+    ])
+  })
+
+  it('should handle case when OPENAI_API_KEY is not set', async () => {
+    // Mock the environment variables without the API key
+    vi.mocked(await import('$env/static/private')).OPENAI_API_KEY = ''
+
+    const messages: Message[] = [
+      {
+        sender: 'partner',
+        text: 'Hello!',
+        timestamp: '2025-05-23T12:00:00Z',
+      },
+    ]
+
+    const result = await getOpenaiReply(messages, 'gentle', '')
+
+    expect(result.summary).toBe('OpenAI API key is not configured.')
+    expect(result.replies).toEqual([
+      'Please set up your OpenAI API key in the .env file.',
+    ])
+  })
+
+  it('should correctly parse replies with special characters', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  function: {
+                    name: 'draft_replies',
+                    arguments: JSON.stringify({
+                      summary: 'Summary goes here.',
+                      replies: [
+                        'This reply has asterisks and quotes',
+                        '"This one has just quotes"',
+                        '*This one has just asterisks*',
+                      ],
+                    }),
+                  },
+                },
+              ],
             },
-            {
-                sender: 'me',
-                text: 'That sounds fun!',
-                timestamp: '2025-05-23T12:01:00Z',
-            },
-        ]
-
-        const result = await getOpenaiReply(messages, 'gentle', '')
-
-        expect(result.summary).toBeTruthy()
-        expect(result.replies.length).toBe(3)
-        expect(result.replies[0]).toContain('excited about the hiking trip')
-
-        // Verify fetch was called with correct parameters
-        expect(global.fetch).toHaveBeenCalledTimes(1)
-        expect(global.fetch).toHaveBeenCalledWith(
-            'https://api.openai.com/v1/chat/completions',
-            expect.objectContaining({
-                method: 'POST',
-                headers: expect.objectContaining({
-                    'Content-Type': 'application/json',
-                    Authorization: 'Bearer test-api-key',
-                }),
-                body: expect.any(String),
-            }),
-        )
-
-        const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
-        expect(body.tools[0].function.name).toBe('draft_replies')
+          },
+        ],
+      }),
     })
 
-    it('should handle API errors gracefully with API key set', async () => {
-        // Mock fetch to return an error
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: false,
-            status: 500,
-            text: vi.fn().mockResolvedValue('Internal Server Error'),
-        })
+    const messages: Message[] = [
+      {
+        sender: 'partner',
+        text: 'Test message',
+        timestamp: '2025-05-23T12:00:00Z',
+      },
+    ]
 
-        const messages: Message[] = [
-            {
-                sender: 'partner',
-                text: 'How are you today?',
-                timestamp: '2025-05-23T12:00:00Z',
-            },
-        ]
+    const result = await getOpenaiReply(messages, 'gentle', '')
 
-        const result = await getOpenaiReply(messages, 'gentle', '')
+    expect(result.summary).toBe('Summary goes here.')
+    expect(result.replies).toEqual([
+      'This reply has asterisks and quotes',
+      '"This one has just quotes"',
+      '*This one has just asterisks*',
+    ])
+  })
 
-        expect(result.summary).toBe('')
-        expect(result.replies).toEqual([
-            '(Sorry, I had trouble generating a response.)',
-        ])
-    })
+  it('includes optional parameters when environment variables are set', async () => {
+    const messages: Message[] = [
+      {
+        sender: 'partner',
+        text: 'Hello!',
+        timestamp: '2025-05-23T12:00:00Z',
+      },
+    ]
 
-    it('should handle case when OPENAI_API_KEY is not set', async () => {
-        // Mock the environment variables without the API key
-        vi.mocked(await import('$env/static/private')).OPENAI_API_KEY = ''
+    await getOpenaiReply(messages, 'gentle', '')
 
-        const messages: Message[] = [
-            {
-                sender: 'partner',
-                text: 'Hello!',
-                timestamp: '2025-05-23T12:00:00Z',
-            },
-        ]
+    const body = getFetchRequestBody<{ top_p: number; frequency_penalty: number; presence_penalty: number }>()
+    expect(body.top_p).toBe(0.7)
+    expect(body.frequency_penalty).toBe(0.1)
+    expect(body.presence_penalty).toBe(0.2)
+  })
 
-        const result = await getOpenaiReply(messages, 'gentle', '')
+  it('omits optional parameters when environment variables are empty', async () => {
+    vi.mocked(await import('$env/static/private')).OPENAI_TOP_P = ''
+    vi.mocked(
+      await import('$env/static/private'),
+    ).OPENAI_FREQUENCY_PENALTY = ''
+    vi.mocked(await import('$env/static/private')).OPENAI_PRESENCE_PENALTY =
+      ''
+    vi.resetModules()
+    const { getOpenaiReply: getOpenaiReplyNoOpts } = await import(
+      '$lib/openAi'
+    )
 
-        expect(result.summary).toBe('OpenAI API key is not configured.')
-        expect(result.replies).toEqual([
-            'Please set up your OpenAI API key in the .env file.',
-        ])
-    })
+    const messages: Message[] = [
+      {
+        sender: 'partner',
+        text: 'Hi',
+        timestamp: '2025-05-23T12:00:00Z',
+      },
+    ]
 
-    it('should correctly parse replies with special characters', async () => {
-        global.fetch = vi.fn().mockResolvedValue({
-            ok: true,
-            json: vi.fn().mockResolvedValue({
-                choices: [
-                    {
-                        message: {
-                            tool_calls: [
-                                {
-                                    function: {
-                                        name: 'draft_replies',
-                                        arguments: JSON.stringify({
-                                            summary: 'Summary goes here.',
-                                            replies: [
-                                                'This reply has asterisks and quotes',
-                                                '"This one has just quotes"',
-                                                '*This one has just asterisks*',
-                                            ],
-                                        }),
-                                    },
-                                },
-                            ],
-                        },
-                    },
-                ],
-            }),
-        })
+    await getOpenaiReplyNoOpts(messages, 'gentle', '')
 
-        const messages: Message[] = [
-            {
-                sender: 'partner',
-                text: 'Test message',
-                timestamp: '2025-05-23T12:00:00Z',
-            },
-        ]
-
-        const result = await getOpenaiReply(messages, 'gentle', '')
-
-        expect(result.summary).toBe('Summary goes here.')
-        expect(result.replies).toEqual([
-            'This reply has asterisks and quotes',
-            '"This one has just quotes"',
-            '*This one has just asterisks*',
-        ])
-    })
-
-    it('includes optional parameters when environment variables are set', async () => {
-        const messages: Message[] = [
-            {
-                sender: 'partner',
-                text: 'Hello!',
-                timestamp: '2025-05-23T12:00:00Z',
-            },
-        ]
-
-        await getOpenaiReply(messages, 'gentle', '')
-
-        const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
-        expect(body.top_p).toBe(0.7)
-        expect(body.frequency_penalty).toBe(0.1)
-        expect(body.presence_penalty).toBe(0.2)
-    })
-
-    it('omits optional parameters when environment variables are empty', async () => {
-        vi.mocked(await import('$env/static/private')).OPENAI_TOP_P = ''
-        vi.mocked(
-            await import('$env/static/private'),
-        ).OPENAI_FREQUENCY_PENALTY = ''
-        vi.mocked(await import('$env/static/private')).OPENAI_PRESENCE_PENALTY =
-            ''
-        vi.resetModules()
-        const { getOpenaiReply: getOpenaiReplyNoOpts } = await import(
-            '$lib/openAi'
-        )
-
-        const messages: Message[] = [
-            {
-                sender: 'partner',
-                text: 'Hi',
-                timestamp: '2025-05-23T12:00:00Z',
-            },
-        ]
-
-        await getOpenaiReplyNoOpts(messages, 'gentle', '')
-
-        const body = JSON.parse((global.fetch as any).mock.calls[0][1].body)
-        expect(body).not.toHaveProperty('top_p')
-        expect(body).not.toHaveProperty('frequency_penalty')
-        expect(body).not.toHaveProperty('presence_penalty')
-        expect(body).not.toHaveProperty('user')
-    })
+    const body = getFetchRequestBody()
+    expect(body).not.toHaveProperty('top_p')
+    expect(body).not.toHaveProperty('frequency_penalty')
+    expect(body).not.toHaveProperty('presence_penalty')
+    expect(body).not.toHaveProperty('user')
+  })
 })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,6 +7,10 @@ global.fetch = vi.fn()
 // Setup environment variables for testing
 process.env.OPENAI_API_KEY = 'test-api-key'
 process.env.OPENAI_MODEL = 'gpt-4'
+process.env.OPENAI_TEMPERATURE = '0.5'
+process.env.OPENAI_TOP_P = '0.7'
+process.env.OPENAI_FREQUENCY_PENALTY = '0.1'
+process.env.OPENAI_PRESENCE_PENALTY = '0.2'
 
 // Reset mocks before each test
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- allow additional optional OpenAI environment variables
- send those values in the `getOpenaiReply` request body when present
- document new variables and explain their purpose
- expand unit tests for optional parameter handling
- remove unused OPENAI_USER and OPENAI_MAX_TOKENS references

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68421b2b8f348320b656d6983f97b416