### PR TITLE
Update message format for AI prompts

### DIFF
--- a/src/lib/khoj.ts
+++ b/src/lib/khoj.ts
@@ -1,5 +1,5 @@
 import { KHOJ_AGENT, KHOJ_API_URL } from '$env/static/private'
-import { PERMANENT_CONTEXT, buildReplyPrompt } from '$lib/prompts'
+import { PERMANENT_CONTEXT, buildKhojPrompt } from '$lib/prompts'
 import type { Message } from '$lib/types'
 import { extractReplies, formatMessages, parseSummaryToHumanReadable } from '$lib/utils'
 import { logger } from './logger'
@@ -12,13 +12,9 @@ export const getKhojReply = async (
     context: string,
 ): Promise<{ summary: string; replies: string[]; messageCount: number }> => {
     const conversation = formatMessages(messages)
-    const prompt = buildReplyPrompt(tone, context)
+    const prompt = buildKhojPrompt(conversation, tone, context)
     const body = {
-        messages: [
-            { role: 'system', content: PERMANENT_CONTEXT },
-            ...conversation,
-            { role: 'user', content: prompt },
-        ],
+        q: prompt,
         ...(KHOJ_AGENT ? { agent: KHOJ_AGENT } : {}),
     }
 

--- a/src/lib/khoj.ts
+++ b/src/lib/khoj.ts
@@ -1,7 +1,7 @@
 import { KHOJ_AGENT, KHOJ_API_URL } from '$env/static/private'
 import { PERMANENT_CONTEXT, buildKhojPrompt } from '$lib/prompts'
 import type { Message } from '$lib/types'
-import { extractReplies, formatMessages, parseSummaryToHumanReadable } from '$lib/utils'
+import { extractReplies, formatAsUserAndAssistant, parseSummaryToHumanReadable } from '$lib/utils'
 import { logger } from './logger'
 
 const khojApiUrl = KHOJ_API_URL || 'http://localhost:42110/api/chat'
@@ -11,7 +11,7 @@ export const getKhojReply = async (
     tone: string,
     context: string,
 ): Promise<{ summary: string; replies: string[]; messageCount: number }> => {
-    const conversation = formatMessages(messages)
+    const conversation = formatAsUserAndAssistant(messages)
     const prompt = buildKhojPrompt(conversation, tone, context)
     const body = {
         q: prompt,

--- a/src/lib/khoj.ts
+++ b/src/lib/khoj.ts
@@ -1,5 +1,5 @@
 import { KHOJ_AGENT, KHOJ_API_URL } from '$env/static/private'
-import { buildReplyPrompt } from '$lib/prompts'
+import { PERMANENT_CONTEXT, buildReplyPrompt } from '$lib/prompts'
 import type { Message } from '$lib/types'
 import { extractReplies, formatMessages, parseSummaryToHumanReadable } from '$lib/utils'
 import { logger } from './logger'
@@ -11,10 +11,14 @@ export const getKhojReply = async (
     tone: string,
     context: string,
 ): Promise<{ summary: string; replies: string[]; messageCount: number }> => {
-    const recentText = formatMessages(messages)
-    const prompt = buildReplyPrompt(recentText, tone, context)
+    const conversation = formatMessages(messages)
+    const prompt = buildReplyPrompt(tone, context)
     const body = {
-        q: prompt,
+        messages: [
+            { role: 'system', content: PERMANENT_CONTEXT },
+            ...conversation,
+            { role: 'user', content: prompt },
+        ],
         ...(KHOJ_AGENT ? { agent: KHOJ_AGENT } : {}),
     }
 

--- a/src/lib/openAi.ts
+++ b/src/lib/openAi.ts
@@ -59,7 +59,7 @@ export const getOpenaiReply = async (
         }
 
     const conversation = formatMessages(messages)
-    const prompt = buildReplyPrompt(conversation, tone, context)
+    const prompt = buildReplyPrompt(tone, context)
 
     logger.debug({ prompt }, 'Sending prompt to OpenAI')
 
@@ -74,6 +74,7 @@ export const getOpenaiReply = async (
                 model: openaiModel,
                 messages: [
                     { role: 'system', content: PERMANENT_CONTEXT },
+                    ...conversation,
                     { role: 'user', content: prompt },
                 ],
                 temperature: openaiTemperature,

--- a/src/lib/openAi.ts
+++ b/src/lib/openAi.ts
@@ -9,7 +9,7 @@ import {
 import { logger } from './logger'
 import { PERMANENT_CONTEXT, buildReplyPrompt } from './prompts'
 import type { Message } from './types'
-import { formatMessages } from './utils'
+import { formatAsUserAndAssistant } from './utils'
 
 const openaiModel = OPENAI_MODEL || 'gpt-4'
 const openaiTemperature = Number.parseFloat(OPENAI_TEMPERATURE || '0.5')
@@ -58,7 +58,7 @@ export const getOpenaiReply = async (
             replies: ['Please set up your OpenAI API key in the .env file.'],
         }
 
-    const conversation = formatMessages(messages)
+    const conversation = formatAsUserAndAssistant(messages)
     const prompt = buildReplyPrompt(tone, context)
 
     logger.debug({ prompt }, 'Sending prompt to OpenAI')

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,3 +1,5 @@
+import type { ChatMessage } from './types'
+
 export const PERMANENT_CONTEXT =
     'Act as my therapist suggesting replies to my partner. Messages with role "user" are from me, and messages with role "assistant" are from my partner. Analyze my messages to mimic my vocabulary and tone when suggesting replies.'
 
@@ -13,3 +15,31 @@ export const buildReplyPrompt = (tone: string, context: string): string => `
     Reply 2: <reply>
     Reply 3: <reply>
 `
+
+export const buildKhojPrompt = (
+    conversation: ChatMessage[],
+    tone: string,
+    context: string,
+): string => {
+    const formattedMessages = conversation
+        .map((msg, idx) => {
+            const tag = msg.role === 'user' ? 'Me' : 'Partner'
+            return `Message ${idx + 1}: ${tag}: ${msg.content}`
+        })
+        .join('\n')
+
+    return `
+        Here are some text messages between my partner and I:
+        ${formattedMessages}
+        Please give a brief summary, including the emotional tone, main topics, and any changes in mood.
+        Suggest 3 replies that I might send.
+        Tone: ${tone}
+        ${context ? `Additional context: ${context}` : ''}
+        Please respond using this format:
+        Summary: <summary>
+        Suggested replies:
+        Reply 1: <reply>
+        Reply 2: <reply>
+        Reply 3: <reply>
+    `
+}

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,21 +1,15 @@
 export const PERMANENT_CONTEXT =
-    'Act as my therapist suggesting replies to my partner. Analyze my messages labeled "Me:" to mimic my vocabulary and tone when suggesting replies.'
+    'Act as my therapist suggesting replies to my partner. Messages with role "user" are from me, and messages with role "assistant" are from my partner. Analyze my messages to mimic my vocabulary and tone when suggesting replies.'
 
-export const buildReplyPrompt = (messages: string[], tone: string, context: string): string => {
-    const formattedMessages = messages.map((msg, idx) => `Message ${idx + 1}: ${msg}`).join('\n')
-
-    return `
-        Here are some text messages between my partner and I:
-        ${formattedMessages}
-        Please give a brief summary, including the emotional tone, main topics, and any changes in mood.
-        Suggest 3 replies that I might send.
-        Tone: ${tone}
-        ${context ? `Additional context: ${context}` : ''}
-        Please respond using this format: 
-        Summary: <summary>
-        Suggested replies:
-        Reply 1: <reply>
-        Reply 2: <reply>
-        Reply 3: <reply>
-    `
-}
+export const buildReplyPrompt = (tone: string, context: string): string => `
+    Given the conversation above, provide a brief summary including the emotional tone, main topics, and any changes in mood.
+    Suggest 3 replies that I might send.
+    Tone: ${tone}
+    ${context ? `Additional context: ${context}` : ''}
+    Please respond using this format:
+    Summary: <summary>
+    Suggested replies:
+    Reply 1: <reply>
+    Reply 2: <reply>
+    Reply 3: <reply>
+`

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,3 +17,8 @@ export interface PageData {
 }
 
 export type ToneType = 'gentle' | 'funny' | 'reassuring' | 'concise'
+
+export interface ChatMessage {
+    role: 'user' | 'assistant'
+    content: string
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,7 +15,7 @@ export const parseSummaryToHumanReadable = (rawOutput: string): string => {
 export const hasPartnerMessages = (formattedRows: Message[]) =>
     formattedRows.some((msg) => msg.sender !== 'me')
 
-export const formatMessages = (messages: Message[]): ChatMessage[] => {
+export const formatAsUserAndAssistant = (messages: Message[]): ChatMessage[] => {
     return messages.map((m) => ({
         role: m.sender === 'me' ? 'user' : 'assistant',
         content: m.text,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import type { Message } from './types'
+import type { ChatMessage, Message } from './types'
 
 export const parseSummaryToHumanReadable = (rawOutput: string): string => {
     const summaryRegex = /Summary:[ \t]*(\n+)?([\s\S]*?)(?=\s*Suggested replies:|$)/
@@ -15,11 +15,11 @@ export const parseSummaryToHumanReadable = (rawOutput: string): string => {
 export const hasPartnerMessages = (formattedRows: Message[]) =>
     formattedRows.some((msg) => msg.sender !== 'me')
 
-export const formatMessages = (messages: Message[]): string[] => {
-    return messages.map((m) => {
-        const tag = m.sender === 'me' ? 'Me' : m.sender === 'partner' ? 'Partner' : m.sender
-        return `${tag}: ${m.text}`
-    })
+export const formatMessages = (messages: Message[]): ChatMessage[] => {
+    return messages.map((m) => ({
+        role: m.sender === 'me' ? 'user' : 'assistant',
+        content: m.text,
+    }))
 }
 
 const cleanReplyText = (text: string): string => {

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { extractReplies, formatMessages, parseSummaryToHumanReadable } from '$lib/utils'
+import { extractReplies, formatAsUserAndAssistant, parseSummaryToHumanReadable } from '$lib/utils'
 import { describe, expect, it } from 'vitest'
 
 describe('parseSummaryToHumanReadable', () => {
@@ -64,7 +64,7 @@ describe('formatMessages', () => {
             { sender: 'partner', text: 'Hi there', timestamp: '2' },
         ]
 
-        const formatted = formatMessages(messages)
+        const formatted = formatAsUserAndAssistant(messages)
 
         expect(formatted).toEqual([
             { role: 'user', content: 'Hello' },

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -66,6 +66,9 @@ describe('formatMessages', () => {
 
         const formatted = formatMessages(messages)
 
-        expect(formatted).toEqual(['Me: Hello', 'Partner: Hi there'])
+        expect(formatted).toEqual([
+            { role: 'user', content: 'Hello' },
+            { role: 'assistant', content: 'Hi there' },
+        ])
     })
 })


### PR DESCRIPTION
## Summary
- switch message formatting to role-based objects
- update OpenAI and Khoj API calls to use conversation objects
- tweak prompt wording for new roles
- test updates for new format

## Testing
- `yarn biome:lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68422b8482e883208ac47d99f7c0953e