### PR TITLE
Add history search context

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Partner
 PARTNER_PHONE=your-partner-phone (eg. +1234567890)
 
+# Search this many hours of prior messages for extra context
+HISTORY_LOOKBACK_HOURS=6
+
 # OpenAI
 OPENAI_API_KEY=your-openai-api-key
 OPENAI_MODEL=gpt-4
@@ -22,9 +25,6 @@ LOG_LEVEL=info
 
 # Allowed Host (see README for more info)
 ALLOWED_HOST=your-allowed-host (eg. yourhost.tailscale.ts.net)
-
-# Search this many hours of prior messages for extra context
-HISTORY_LOOKBACK_HOURS=6
 
 # Auth (see README for more info)
 JWT_SECRET=your-jwt-secret

--- a/.env.example
+++ b/.env.example
@@ -23,5 +23,8 @@ LOG_LEVEL=info
 # Allowed Host (see README for more info)
 ALLOWED_HOST=your-allowed-host (eg. yourhost.tailscale.ts.net)
 
+# Search this many hours of prior messages for extra context
+HISTORY_LOOKBACK_HOURS=6
+
 # Auth (see README for more info)
 JWT_SECRET=your-jwt-secret

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ LOG_LEVEL=info
 
 # For remote access via Tailscale (see 'Accessing from Anywhere' section)
 ALLOWED_HOST=your-tailscale-hostname.your-tailscale-domain.ts.net
+
+# How many hours of prior conversation history to search for extra context
+HISTORY_LOOKBACK_HOURS=6
 ```
 
 **Important Note on `JWT_SECRET`**: 

--- a/src/lib/components/ReplySuggestions.svelte
+++ b/src/lib/components/ReplySuggestions.svelte
@@ -74,6 +74,7 @@ let copiedIndex = $state(-1)
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
         display: flex;
         align-items: flex-start;
+        justify-content: space-between;
     }
     
     .copy-button {

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -12,12 +12,8 @@ export const fetchRelevantHistory = async (
 
     try {
         const now = new Date()
-        let end = new Date(messages[0].timestamp)
+        const end = new Date(messages[0].timestamp)
         const start = new Date(now.getTime() - lookbackHours * 60 * 60 * 1000)
-
-        // Ensure we're not looking into the future
-        if (start > now) return ''
-        if (end > now) end = now
 
         logger.debug({
             lookbackHours,

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,0 +1,29 @@
+import { HISTORY_LOOKBACK_HOURS } from '$env/static/private'
+import { queryMessagesDb } from '$lib/iMessages'
+import type { Message } from '$lib/types'
+import { logger } from './logger'
+
+const lookbackHours = Number.parseInt(HISTORY_LOOKBACK_HOURS || '0')
+
+export const fetchRelevantHistory = async (
+    messages: Message[],
+): Promise<string> => {
+    if (!lookbackHours || messages.length === 0) return ''
+
+    try {
+        const first = new Date(messages[0].timestamp)
+        const start = new Date(first.getTime() - lookbackHours * 60 * 60 * 1000)
+        const { messages: history } = await queryMessagesDb(
+            start.toISOString(),
+            first.toISOString(),
+        )
+        const context = history
+            .map((m) => `${m.sender === 'me' ? 'Me' : 'Partner'}: ${m.text}`)
+            .join('\n')
+        logger.debug({ context }, 'Fetched additional history context')
+        return context
+    } catch (err) {
+        logger.error({ err }, 'Failed to fetch history context')
+        return ''
+    }
+}

--- a/src/lib/iMessages.ts
+++ b/src/lib/iMessages.ts
@@ -1,11 +1,11 @@
 import os from 'node:os'
 import path from 'node:path'
+import { PARTNER_PHONE } from '$env/static/private'
 import type { MessageRow } from '$lib/types'
 import { open } from 'sqlite'
 import sqlite3 from 'sqlite3'
 import { logger } from './logger'
 import { hasPartnerMessages } from './utils'
-import { PARTNER_PHONE } from '$env/static/private'
 
 const CHAT_DB_PATH = path.join(os.homedir(), 'Library', 'Messages', 'chat.db')
 
@@ -54,6 +54,8 @@ export const queryMessagesDb = async (startDate?: string, endDate?: string) => {
         ${dateWhere}
         ORDER BY message.date DESC`
 
+    logger.debug({ query, params }, 'Querying messages database')
+
     let rows: MessageRow[] = []
 
     try {
@@ -74,8 +76,8 @@ export const queryMessagesDb = async (startDate?: string, endDate?: string) => {
             sender: row.is_from_me
                 ? 'me'
                 : row.contact_id === PARTNER_HANDLE_ID
-                  ? 'partner'
-                  : 'unknown',
+                    ? 'partner'
+                    : 'unknown',
             text: row.text,
             timestamp: row.timestamp,
         }))

--- a/src/lib/openAi.ts
+++ b/src/lib/openAi.ts
@@ -7,6 +7,7 @@ import {
     OPENAI_TOP_P,
 } from '$env/static/private'
 import { logger } from './logger'
+import { fetchRelevantHistory } from './history'
 import { PERMANENT_CONTEXT, buildReplyPrompt } from './prompts'
 import type { Message } from './types'
 import { formatAsUserAndAssistant } from './utils'
@@ -59,7 +60,9 @@ export const getOpenaiReply = async (
         }
 
     const conversation = formatAsUserAndAssistant(messages)
-    const prompt = buildReplyPrompt(tone, context)
+    const historyContext = await fetchRelevantHistory(messages)
+    const mergedContext = [historyContext, context].filter(Boolean).join('\n')
+    const prompt = buildReplyPrompt(tone, mergedContext)
 
     logger.debug({ prompt }, 'Sending prompt to OpenAI')
 

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,7 +1,7 @@
 import type { ChatMessage } from './types'
 
 export const PERMANENT_CONTEXT =
-    'Act as my therapist suggesting replies to my partner. Messages with role "user" are from me, and messages with role "assistant" are from my partner. Analyze my messages to mimic my vocabulary and tone when suggesting replies.\n\n' +
+    'Act as my therapist suggesting replies to my partner. Messages with role "user" are from me. Messages with role "assistant" are from my partner. Analyze my messages to mimic my vocabulary and tone when suggesting replies.\n\n' +
     'Additional context about recent conversation history is provided below. Use this to understand the current situation and tone, but focus your reply on the most recent messages. Do not summarize the history - it is only for context.'
 
 export const buildReplyPrompt = (tone: string, context: string): string => `

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,13 +1,14 @@
 import type { ChatMessage } from './types'
 
 export const PERMANENT_CONTEXT =
-    'Act as my therapist suggesting replies to my partner. Messages with role "user" are from me, and messages with role "assistant" are from my partner. Analyze my messages to mimic my vocabulary and tone when suggesting replies.'
+    'Act as my therapist suggesting replies to my partner. Messages with role "user" are from me, and messages with role "assistant" are from my partner. Analyze my messages to mimic my vocabulary and tone when suggesting replies.\n\n' +
+    'Additional context about recent conversation history is provided below. Use this to understand the current situation and tone, but focus your reply on the most recent messages. Do not summarize the history - it is only for context.'
 
 export const buildReplyPrompt = (tone: string, context: string): string => `
     Given the conversation above, provide a brief summary including the emotional tone, main topics, and any changes in mood.
-    Suggest 3 replies that I might send.
+    Suggest 3 replies that I might send. Focus on the most recent messages when crafting replies.
     Tone: ${tone}
-    ${context ? `Additional context: ${context}` : ''}
+    ${context ? `Recent conversation context (for reference only):\n${context}\n` : ''}
     Please respond using this format:
     Summary: <summary>
     Suggested replies:
@@ -31,10 +32,13 @@ export const buildKhojPrompt = (
     return `
         Here are some text messages between my partner and I:
         ${formattedMessages}
+        
         Please give a brief summary, including the emotional tone, main topics, and any changes in mood.
-        Suggest 3 replies that I might send.
+        Suggest 3 replies that I might send. Focus on the most recent messages when crafting replies.
+        
         Tone: ${tone}
-        ${context ? `Additional context: ${context}` : ''}
+        ${context ? `Recent conversation context (for reference only):\n${context}\n` : ''}
+        
         Please respond using this format:
         Summary: <summary>
         Suggested replies:

--- a/tests/lib/history.test.ts
+++ b/tests/lib/history.test.ts
@@ -1,0 +1,48 @@
+import { fetchRelevantHistory } from '$lib/history'
+import type { Message } from '$lib/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('$lib/iMessages', () => ({
+    queryMessagesDb: vi.fn(),
+}))
+
+vi.mock('$env/static/private', () => ({
+    HISTORY_LOOKBACK_HOURS: '1',
+    LOG_LEVEL: 'info',
+}))
+
+const { queryMessagesDb } = await import('$lib/iMessages')
+
+describe('fetchRelevantHistory', () => {
+    beforeEach(() => {
+        vi.resetAllMocks()
+    })
+
+    it('returns empty string when no history found', async () => {
+        vi.mocked(queryMessagesDb).mockResolvedValue({ messages: [] })
+        const messages: Message[] = [
+            { sender: 'partner', text: 'hi', timestamp: '2025-05-20T10:00:00Z' },
+        ]
+        const result = await fetchRelevantHistory(messages)
+        expect(result).toBe('')
+    })
+
+    it('returns formatted history when messages exist', async () => {
+        vi.mocked(queryMessagesDb).mockResolvedValue({
+            messages: [
+                { sender: 'me', text: 'old1', timestamp: '2025-05-19T09:00:00Z' },
+                {
+                    sender: 'partner',
+                    text: 'old2',
+                    timestamp: '2025-05-19T09:05:00Z',
+                },
+            ],
+        })
+        const messages: Message[] = [
+            { sender: 'partner', text: 'hi', timestamp: '2025-05-20T10:00:00Z' },
+        ]
+        const result = await fetchRelevantHistory(messages)
+        expect(result).toContain('Me: old1')
+        expect(result).toContain('Partner: old2')
+    })
+})

--- a/tests/lib/openAi.test.ts
+++ b/tests/lib/openAi.test.ts
@@ -24,6 +24,10 @@ vi.mock('$env/static/private', async (importOriginal) => {
     }
 })
 
+vi.mock('$lib/history', () => ({
+    fetchRelevantHistory: vi.fn().mockResolvedValue('old context'),
+}))
+
 describe('getOpenaiReply', () => {
     beforeEach(async () => {
         vi.clearAllMocks()


### PR DESCRIPTION
## Summary
- fetch earlier history for context when suggesting replies
- include history context in OpenAI and Khoj prompts
- expose `HISTORY_LOOKBACK_HOURS` env variable
- document new env var
- test history helper
- mock history in OpenAI tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684234d38de88320afca00075c1ab43d