### PR TITLE
Improve reply generation prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ WellSaid is an empathy-focused communication tool that helps you craft better re
 ## Features
 
 - **Conversation Summaries**: Analyze your Messages app conversations with a partner from the last 1-24 hours
-- **Smart Reply Suggestions**: Get AI-generated reply options (via OpenAI or a local Khoj server) based on conversation context
+- **Smart Reply Suggestions**: Get short, medium, and long AI-generated reply options (via OpenAI or a local Khoj server) based on conversation context
 - **Conversation History Context**: Considers recent message history (configurable via `HISTORY_LOOKBACK_HOURS`) to provide more contextually relevant suggestions
 - **Tone Selection**: Choose from four different tones for your replies:
   - Gentle 
@@ -146,7 +146,7 @@ yarn dev
 WellSaid connects to your macOS Messages database to fetch your conversations with a specific contact (set via the `PARTNER_PHONE` environment variable). It then uses an AI provider (OpenAI's API by default, or a configured local Khoj server if `KHOJ_API_URL` is set) to analyze the conversation and generate:
 
 1. A summary of the conversation, including emotional tone and key topics
-1. Three suggested replies in your chosen tone
+1. Three suggested replies (short, medium, and long) in your chosen tone
 
 ## Technical Details
 

--- a/src/lib/openAi.ts
+++ b/src/lib/openAi.ts
@@ -34,7 +34,8 @@ const summaryFunction = {
     type: 'function',
     function: {
         name: 'draft_replies',
-        description: 'Generate a short summary and three suggested replies',
+        description:
+            'Generate a short summary and three suggested replies (short, medium, and long)',
         parameters: {
             type: 'object',
             properties: {

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -5,15 +5,15 @@ export const PERMANENT_CONTEXT = `${CUSTOM_CONTEXT}\n\nMessages with role "user"
 
 export const buildReplyPrompt = (tone: string, context: string): string => `
     Given the conversation above, provide a brief summary including the emotional tone, main topics, and any changes in mood.
-    Suggest 3 replies that I might send. Focus on the most recent messages when crafting replies.
+    Suggest 3 replies that I might send. Provide one short reply, one medium-length reply, and one long reply. Focus on the most recent messages when crafting replies.
     Tone: ${tone}
     ${context ? `Recent conversation context (for reference only):\n${context}\n` : ''}
     Please respond using this format:
     Summary: <summary>
     Suggested replies:
-    Reply 1: <reply>
-    Reply 2: <reply>
-    Reply 3: <reply>
+    Reply 1: <short reply>
+    Reply 2: <medium reply>
+    Reply 3: <long reply>
 `
 
 export const buildKhojPrompt = (
@@ -33,7 +33,7 @@ export const buildKhojPrompt = (
         ${formattedMessages}
         
         Please give a brief summary, including the emotional tone, main topics, and any changes in mood.
-        Suggest 3 replies that I might send. Focus on the most recent messages when crafting replies.
+        Suggest 3 replies that I might send. Provide one short reply, one medium-length reply, and one long reply. Focus on the most recent messages when crafting replies.
         
         Tone: ${tone}
         ${context ? `Recent conversation context (for reference only):\n${context}\n` : ''}
@@ -41,8 +41,8 @@ export const buildKhojPrompt = (
         Please respond using this format:
         Summary: <summary>
         Suggested replies:
-        Reply 1: <reply>
-        Reply 2: <reply>
-        Reply 3: <reply>
+        Reply 1: <short reply>
+        Reply 2: <medium reply>
+        Reply 3: <long reply>
     `
 }


### PR DESCRIPTION
## Summary
- let AI generate short, medium, and long replies
- document the new reply lengths in the README

## Testing
- `yarn lint`
- `npx svelte-kit sync`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6843bbf1d74483208ec145849a9de1d3