### PR TITLE
Fix timestamp parsing

### DIFF
--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -20,7 +20,7 @@ export const fetchRelevantHistory = async (messages: Message[]): Promise<string>
             return ''
         }
 
-        const earliestTimestampMs = new Date(messages[0].timestamp).getTime() - 60 * 60 * 7000
+        const earliestTimestampMs = new Date(messages[0].timestamp).getTime()
         const end = new Date(earliestTimestampMs - 1) // exclude the current message
         const start = new Date(end.getTime() - lookbackHours * 60 * 60 * 1000)
 

--- a/src/lib/iMessages.ts
+++ b/src/lib/iMessages.ts
@@ -39,7 +39,9 @@ const formatMessages = (rows: MessageRow[]) => {
         .map((row) => ({
             sender: row.is_from_me ? 'me' : row.contact_id === PARTNER_PHONE ? 'partner' : 'unknown',
             text: row.text,
-            timestamp: new Date(row.timestamp).toISOString()
+            timestamp: new Date(
+                row.timestamp.endsWith('Z') ? row.timestamp : `${row.timestamp}Z`
+            ).toISOString()
         }))
         .reverse() // Reverse to get chronological order
 }


### PR DESCRIPTION
## Summary
- interpret DB timestamps as UTC
- stop manually shifting timestamps by 7 hours

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684b334323e88320a05bf350811e2a30