### PR TITLE
Improve test coverage

### DIFF
--- a/tests/lib/khoj.test.ts
+++ b/tests/lib/khoj.test.ts
@@ -1,0 +1,60 @@
+import { getKhojReply } from '$lib/khoj'
+import type { Message } from '$lib/types'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('$lib/history', () => ({
+    fetchRelevantHistory: vi.fn().mockResolvedValue('history context'),
+}))
+
+vi.mock('$lib/prompts', () => ({
+    khojPrompt: vi.fn().mockReturnValue('prompt'),
+}))
+
+vi.mock('$env/static/private', async (importOriginal) => {
+    const actual = (await importOriginal()) as Record<string, string | undefined>
+    return {
+        ...actual,
+        KHOJ_API_URL: 'http://khoj.test/api',
+        KHOJ_AGENT: '',
+        LOG_LEVEL: 'info',
+    }
+})
+
+describe('getKhojReply', () => {
+    beforeEach(() => {
+        vi.resetAllMocks()
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({
+                response: 'Summary: hi\n\nSuggested replies:\nReply 1: r1\nReply 2: r2',
+            }),
+        })
+    })
+
+    it('returns parsed summary and replies on success', async () => {
+        const messages: Message[] = [{ sender: 'me', text: 'hi', timestamp: '1' }]
+        const result = await getKhojReply(messages, 'gentle', '')
+
+        expect(result.summary).toBe('hi')
+        expect(result.replies).toEqual(['r1', 'r2'])
+        expect(result.messageCount).toBe(1)
+        expect(global.fetch).toHaveBeenCalledWith(
+            'http://khoj.test/api',
+            expect.objectContaining({
+                method: 'POST',
+            })
+        )
+    })
+
+    it('handles fetch failure gracefully', async () => {
+        ;(global.fetch as unknown as vi.Mock).mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            json: vi.fn(),
+        })
+        const messages: Message[] = [{ sender: 'me', text: 'hi', timestamp: '1' }]
+        const result = await getKhojReply(messages, 'gentle', '')
+        expect(result.replies).toEqual(['(AI API error. Check your key and usage.)'])
+        expect(result.summary).toBe('')
+    })
+})

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -4,6 +4,7 @@ import {
     formatMessagesAsText,
     hasPartnerMessages,
     safeCompare,
+    isoToAppleNanoseconds,
 } from '$lib/utils'
 import { describe, expect, it } from 'vitest'
 
@@ -157,5 +158,19 @@ describe('safeCompare', () => {
         const special = '!@#$%^&*()_+-=[]{}|;:,.<>?'
         expect(safeCompare(special, special)).toBe(true)
         expect(safeCompare(special, special + 'x')).toBe(false)
+    })
+})
+
+describe('isoToAppleNanoseconds', () => {
+    it('converts ISO date to Apple epoch nanoseconds', () => {
+        const iso = '2001-01-02T00:00:00Z'
+        const expected = 86400 * 1_000_000_000
+        expect(isoToAppleNanoseconds(iso)).toBe(expected)
+    })
+
+    it('handles dates before the epoch', () => {
+        const iso = '2000-12-31T23:59:59Z'
+        const result = isoToAppleNanoseconds(iso)
+        expect(result).toBeLessThan(0)
     })
 })

--- a/tests/routes/root/server.test.ts
+++ b/tests/routes/root/server.test.ts
@@ -1,11 +1,13 @@
 import * as queryDb from '$lib/iMessages'
 import * as openai from '$lib/openAi'
+import * as khoj from '$lib/khoj'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as serverModule from '../../../src/routes/+page.server'
 import type { RequestEvent } from '@sveltejs/kit'
 
 vi.mock('$lib/iMessages', () => ({ queryMessagesDb: vi.fn() }))
 vi.mock('$lib/openAi', () => ({ getOpenaiReply: vi.fn() }))
+vi.mock('$lib/khoj', () => ({ getKhojReply: vi.fn() }))
 vi.mock('$lib/logger', () => ({
     logger: {
         error: vi.fn(),
@@ -115,6 +117,72 @@ describe('root page server', () => {
             [{ text: 'test', sender: 'user', timestamp: '2025-01-01T00:00:00Z' }],
             'gentle',
             'test context'
+        )
+    })
+
+    it('uses Khoj provider when specified', async () => {
+        const mockResponse = { summary: 'sum', replies: ['r1'], messageCount: 1 }
+        vi.mocked(khoj.getKhojReply).mockResolvedValue(mockResponse)
+
+        const formData = new FormData()
+        formData.append(
+            'messages',
+            JSON.stringify([{ text: 'hi', sender: 'me', timestamp: '2025-01-01T00:00:00Z' }])
+        )
+        formData.append('tone', 'gentle')
+        formData.append('context', '')
+        formData.append('provider', 'khoj')
+
+        const request = new Request('https://example.com/', { method: 'POST', body: formData })
+        const event = { ...createMockRequestEvent(new URL('https://example.com/')), request }
+
+        const result = await serverModule.actions.generate({
+            request: event.request,
+            cookies: event.cookies,
+            fetch: event.fetch,
+            getClientAddress: event.getClientAddress,
+            locals: {},
+            params: {},
+            platform: undefined,
+            route: { id: '/' },
+            setHeaders: vi.fn(),
+            url: event.url,
+            isDataRequest: false,
+            isSubRequest: false,
+        } as unknown as Parameters<typeof serverModule.actions.generate>[0])
+
+        expect(result).toEqual(mockResponse)
+        expect(khoj.getKhojReply).toHaveBeenCalled()
+    })
+
+    it('returns 400 when messages JSON is invalid', async () => {
+        const formData = new FormData()
+        formData.append('messages', 'not json')
+        formData.append('tone', 'gentle')
+        formData.append('context', '')
+        formData.append('provider', 'openai')
+
+        const request = new Request('https://example.com/', { method: 'POST', body: formData })
+        const event = { ...createMockRequestEvent(new URL('https://example.com/')), request }
+
+        const result = await serverModule.actions.generate({
+            request: event.request,
+            cookies: event.cookies,
+            fetch: event.fetch,
+            getClientAddress: event.getClientAddress,
+            locals: {},
+            params: {},
+            platform: undefined,
+            route: { id: '/' },
+            setHeaders: vi.fn(),
+            url: event.url,
+            isDataRequest: false,
+            isSubRequest: false,
+        } as unknown as Parameters<typeof serverModule.actions.generate>[0])
+
+        expect(result.status).toBe(400)
+        expect(result.data.error).toBe(
+            'Invalid messages format in FormData: Messages could not be parsed to an array.'
         )
     })
 })


### PR DESCRIPTION
## Summary
- add coverage for Khoj reply parsing and network failures
- test isoToAppleNanoseconds utility
- cover using the Khoj provider and malformed messages in root action

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684b4a7845b0832091f22adfe682439a