### PR TITLE
fix login cookie over http

### DIFF
--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -28,10 +28,15 @@ export const actions: Actions = {
             // Validate credentials
             if (safeCompare(username, APP_USERNAME) && safeCompare(password, APP_PASSWORD)) {
                 // Create authentication cookie (session-based authentication)
+                const requestUrl = new URL(request.url)
+                const forwardedProto = request.headers.get('x-forwarded-proto')
+                const proto = forwardedProto?.split(',')[0].trim() || requestUrl.protocol
+                const isHttps = proto.toLowerCase().startsWith('https')
+
                 const cookieOptions = {
                     path: '/' as const,
                     httpOnly: true,
-                    secure: true,
+                    secure: isHttps,
                     sameSite: 'strict' as const,
                     maxAge: AUTH_COOKIE_MAX_AGE,
                 }


### PR DESCRIPTION
## Summary
- ensure the auth cookie's secure flag also honors `x-forwarded-proto`
- test login cookies behind proxies

## Testing
- `yarn format src/routes/login/+page.server.ts tests/routes/login/server.test.ts`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68523ba3c71483208dbefea2aba4c279