### PR TITLE
Default to local Khoj provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ PARTNER_PHONE=your-partner-phone (eg. +1234567890)
 # Search this many hours of prior messages for extra context
 HISTORY_LOOKBACK_HOURS=6
 
-# OpenAI
+# OpenAI (used if KHOJ_API_URL is not set)
 OPENAI_API_KEY=your-openai-api-key
 OPENAI_MODEL=gpt-4
 OPENAI_TEMPERATURE=0.5 # Between 0.0 (robotic or repetitive) and 1.0 (random or flippant)
@@ -12,7 +12,8 @@ OPENAI_TOP_P=0.8 # Between 0.0 (most likely) and 1.0 (most diverse)
 OPENAI_FREQUENCY_PENALTY=0.2 # Between 0.0 (no penalty) and 1.0 (strong penalty)
 OPENAI_PRESENCE_PENALTY=0.2 # Between 0.0 (no penalty) and 1.0 (strong penalty)
 
-# KHOJ
+# Khoj (preferred local provider)
+# If this is unset, the app falls back to OpenAI
 KHOJ_API_URL=http://127.0.0.1:42110/api/chat
 KHOJ_AGENT=agent-name
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
   <h3 align="center">Empathy. Upgraded.</h3>
   <p align="center">
 
-  ![GitHub release](https://img.shields.io/github/v/release/splinesreticulating/WellSaid)
-  ![GitHub](https://img.shields.io/github/license/splinesreticulating/WellSaid)
-  ![GitHub](https://img.shields.io/github/issues/splinesreticulating/WellSaid)
-  ![GitHub](https://img.shields.io/github/commit-activity/w/splinesreticulating/WellSaid)
-  ![GitHub](https://img.shields.io/github/last-commit/splinesreticulating/WellSaid)
-      
+![GitHub release](https://img.shields.io/github/v/release/splinesreticulating/WellSaid)
+![GitHub](https://img.shields.io/github/license/splinesreticulating/WellSaid)
+![GitHub](https://img.shields.io/github/issues/splinesreticulating/WellSaid)
+![GitHub](https://img.shields.io/github/commit-activity/w/splinesreticulating/WellSaid)
+![GitHub](https://img.shields.io/github/last-commit/splinesreticulating/WellSaid)
+
   </p>
 
   <p align="center">WellSaid helps you communicate with more empathy and clarity by offering conversation summaries and tone-based reply suggestions.</p>

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -11,5 +11,6 @@ declare namespace App {
         OPENAI_FREQUENCY_PENALTY?: string
         OPENAI_PRESENCE_PENALTY?: string
         CUSTOM_CONTEXT?: string
+        DEFAULT_PROVIDER?: 'khoj' | 'openai'
     }
 }

--- a/src/lib/components/AiProviderSelector.svelte
+++ b/src/lib/components/AiProviderSelector.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
-    let { value = $bindable('openai') }: { value: string } = $props()
+    import type { ProviderConfig } from '$lib/providers/registry'
+
+    let { 
+        value = $bindable('openai'), 
+        providers = [] 
+    }: { 
+        value: string
+        providers: ProviderConfig[]
+    } = $props()
 </script>
 
 <section>
     <select id="ai-provider-select" bind:value>
-        <option value="openai">openai</option>
-        <option value="khoj">khoj</option>
+        {#each providers as provider (provider.id)}
+            <option value={provider.id}>{provider.displayName}</option>
+        {/each}
     </select>
 </section>
 

--- a/src/lib/components/AiProviderSelector.svelte
+++ b/src/lib/components/AiProviderSelector.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
     import type { ProviderConfig } from '$lib/providers/registry'
 
-    let { 
-        value = $bindable('openai'), 
-        providers = [] 
-    }: { 
+    let {
+        value = $bindable('openai'),
+        providers = [],
+    }: {
         value: string
         providers: ProviderConfig[]
     } = $props()

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -32,18 +32,12 @@ const buildPrompt = (tone: string, context: string): string => {
     return lines.join('\n')
 }
 
-export const openAiPrompt = (tone: string, context: string): string =>
-    buildPrompt(tone, context)
+export const openAiPrompt = (tone: string, context: string): string => buildPrompt(tone, context)
 
-export const khojPrompt = (
-    messages: Message[],
-    tone: ToneType,
-    context: string
-): string =>
+export const khojPrompt = (messages: Message[], tone: ToneType, context: string): string =>
     [
         systemContext,
-        'Here are some text messages between my partner and I:\n' +
-            formatMessagesAsText(messages),
+        'Here are some text messages between my partner and I:\n' + formatMessagesAsText(messages),
         buildPrompt(tone, context),
         responseFormat,
     ].join('\n')

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -1,0 +1,8 @@
+import { KHOJ_API_URL, OPENAI_API_KEY } from '$env/static/private'
+
+export const DEFAULT_PROVIDER: 'khoj' | 'openai' = KHOJ_API_URL ? 'khoj' : 'openai'
+
+if (!KHOJ_API_URL && !OPENAI_API_KEY) {
+    console.error('Error: Set KHOJ_API_URL or OPENAI_API_KEY in your .env file')
+    process.exit(1)
+}

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -1,8 +1,6 @@
-import { KHOJ_API_URL, OPENAI_API_KEY } from '$env/static/private'
+import { getDefaultProvider, validateProviders } from './providers/registry'
 
-export const DEFAULT_PROVIDER: 'khoj' | 'openai' = KHOJ_API_URL ? 'khoj' : 'openai'
+export const DEFAULT_PROVIDER = getDefaultProvider()
 
-if (!KHOJ_API_URL && !OPENAI_API_KEY) {
-    console.error('Error: Set KHOJ_API_URL or OPENAI_API_KEY in your .env file')
-    process.exit(1)
-}
+// Validate that at least one provider is configured
+validateProviders()

--- a/src/lib/providers/registry.ts
+++ b/src/lib/providers/registry.ts
@@ -11,17 +11,17 @@ export interface ProviderConfig {
 // Registry of all possible AI providers
 const PROVIDER_REGISTRY: Omit<ProviderConfig, 'isAvailable'>[] = [
     {
-        id: 'openai',
-        name: 'OpenAI',
-        displayName: 'OpenAI (GPT)',
-        envVar: 'OPENAI_API_KEY'
-    },
-    {
         id: 'khoj',
         name: 'Khoj',
         displayName: 'Khoj (Local)',
-        envVar: 'KHOJ_API_URL'
-    }
+        envVar: 'KHOJ_API_URL',
+    },
+    {
+        id: 'openai',
+        name: 'OpenAI',
+        displayName: 'OpenAI (GPT)',
+        envVar: 'OPENAI_API_KEY',
+    },
     // Future providers can be added here with their corresponding env vars
     // {
     //     id: 'anthropic',
@@ -40,7 +40,7 @@ const PROVIDER_REGISTRY: Omit<ProviderConfig, 'isAvailable'>[] = [
 // Environment variable lookup
 const ENV_VARS: Record<string, string | undefined> = {
     OPENAI_API_KEY,
-    KHOJ_API_URL
+    KHOJ_API_URL,
     // Add new env vars here as they become available
     // ANTHROPIC_API_KEY,
     // GOOGLE_API_KEY
@@ -50,10 +50,10 @@ const ENV_VARS: Record<string, string | undefined> = {
  * Get all available AI providers based on configured environment variables
  */
 export function getAvailableProviders(): ProviderConfig[] {
-    return PROVIDER_REGISTRY.map(provider => ({
+    return PROVIDER_REGISTRY.map((provider) => ({
         ...provider,
-        isAvailable: !!ENV_VARS[provider.envVar]
-    })).filter(provider => provider.isAvailable)
+        isAvailable: !!ENV_VARS[provider.envVar],
+    })).filter((provider) => provider.isAvailable)
 }
 
 /**
@@ -61,13 +61,15 @@ export function getAvailableProviders(): ProviderConfig[] {
  */
 export function getDefaultProvider(): string {
     const available = getAvailableProviders()
-    
+
     if (available.length === 0) {
-        throw new Error('No AI providers are configured. Please set at least one provider environment variable.')
+        throw new Error(
+            'No AI providers are configured. Please set at least one provider environment variable.'
+        )
     }
-    
+
     // Prefer Khoj if available, otherwise use the first available provider
-    const khojProvider = available.find(p => p.id === 'khoj')
+    const khojProvider = available.find((p) => p.id === 'khoj')
     return khojProvider ? 'khoj' : available[0].id
 }
 
@@ -83,10 +85,12 @@ export function hasMultipleProviders(): boolean {
  */
 export function validateProviders(): void {
     const available = getAvailableProviders()
-    
+
     if (available.length === 0) {
-        console.error('Error: No AI providers are configured. Set at least one of the following environment variables:')
-        PROVIDER_REGISTRY.forEach(provider => {
+        console.error(
+            'Error: No AI providers are configured. Set at least one of the following environment variables:'
+        )
+        PROVIDER_REGISTRY.forEach((provider) => {
             console.error(`  - ${provider.envVar} (for ${provider.displayName})`)
         })
         process.exit(1)

--- a/src/lib/providers/registry.ts
+++ b/src/lib/providers/registry.ts
@@ -1,0 +1,94 @@
+import { KHOJ_API_URL, OPENAI_API_KEY } from '$env/static/private'
+
+export interface ProviderConfig {
+    id: string
+    name: string
+    displayName: string
+    envVar: string
+    isAvailable: boolean
+}
+
+// Registry of all possible AI providers
+const PROVIDER_REGISTRY: Omit<ProviderConfig, 'isAvailable'>[] = [
+    {
+        id: 'openai',
+        name: 'OpenAI',
+        displayName: 'OpenAI (GPT)',
+        envVar: 'OPENAI_API_KEY'
+    },
+    {
+        id: 'khoj',
+        name: 'Khoj',
+        displayName: 'Khoj (Local)',
+        envVar: 'KHOJ_API_URL'
+    }
+    // Future providers can be added here with their corresponding env vars
+    // {
+    //     id: 'anthropic',
+    //     name: 'Anthropic',
+    //     displayName: 'Anthropic (Claude)',
+    //     envVar: 'ANTHROPIC_API_KEY'
+    // },
+    // {
+    //     id: 'gemini',
+    //     name: 'Google',
+    //     displayName: 'Google (Gemini)',
+    //     envVar: 'GOOGLE_API_KEY'
+    // }
+]
+
+// Environment variable lookup
+const ENV_VARS: Record<string, string | undefined> = {
+    OPENAI_API_KEY,
+    KHOJ_API_URL
+    // Add new env vars here as they become available
+    // ANTHROPIC_API_KEY,
+    // GOOGLE_API_KEY
+}
+
+/**
+ * Get all available AI providers based on configured environment variables
+ */
+export function getAvailableProviders(): ProviderConfig[] {
+    return PROVIDER_REGISTRY.map(provider => ({
+        ...provider,
+        isAvailable: !!ENV_VARS[provider.envVar]
+    })).filter(provider => provider.isAvailable)
+}
+
+/**
+ * Get the default provider (prioritizes Khoj if available, falls back to OpenAI)
+ */
+export function getDefaultProvider(): string {
+    const available = getAvailableProviders()
+    
+    if (available.length === 0) {
+        throw new Error('No AI providers are configured. Please set at least one provider environment variable.')
+    }
+    
+    // Prefer Khoj if available, otherwise use the first available provider
+    const khojProvider = available.find(p => p.id === 'khoj')
+    return khojProvider ? 'khoj' : available[0].id
+}
+
+/**
+ * Check if multiple providers are available
+ */
+export function hasMultipleProviders(): boolean {
+    return getAvailableProviders().length > 1
+}
+
+/**
+ * Validate that at least one provider is configured
+ */
+export function validateProviders(): void {
+    const available = getAvailableProviders()
+    
+    if (available.length === 0) {
+        console.error('Error: No AI providers are configured. Set at least one of the following environment variables:')
+        PROVIDER_REGISTRY.forEach(provider => {
+            console.error(`  - ${provider.envVar} (for ${provider.displayName})`)
+        })
+        process.exit(1)
+    }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,7 @@ export interface MessageRow {
 export interface PageData {
     messages?: Message[]
     multiProvider: boolean
+    defaultProvider: 'khoj' | 'openai'
 }
 
 export const TONES = ['gentle', 'funny', 'reassuring', 'concise'] as const

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -4,6 +4,7 @@ import { getKhojReply } from '$lib/khoj'
 import { logger } from '$lib/logger'
 import { getOpenaiReply } from '$lib/openAi'
 import { DEFAULT_PROVIDER } from '$lib/provider'
+import { getAvailableProviders, hasMultipleProviders } from '$lib/providers/registry'
 import type { Message, ToneType } from '$lib/types'
 import { fail } from '@sveltejs/kit'
 import type { Actions, PageServerLoad } from './$types'
@@ -18,8 +19,9 @@ export const load: PageServerLoad = async ({ url }) => {
 
     return {
         messages,
-        multiProvider: !!(KHOJ_API_URL && OPENAI_API_KEY),
+        multiProvider: hasMultipleProviders(),
         defaultProvider: DEFAULT_PROVIDER,
+        availableProviders: getAvailableProviders(),
     }
 }
 

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,4 +1,3 @@
-import { KHOJ_API_URL, OPENAI_API_KEY } from '$env/static/private'
 import { queryMessagesDb } from '$lib/iMessages'
 import { getKhojReply } from '$lib/khoj'
 import { logger } from '$lib/logger'

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,8 +1,9 @@
-import { KHOJ_API_URL } from '$env/static/private'
+import { KHOJ_API_URL, OPENAI_API_KEY } from '$env/static/private'
 import { queryMessagesDb } from '$lib/iMessages'
 import { getKhojReply } from '$lib/khoj'
 import { logger } from '$lib/logger'
 import { getOpenaiReply } from '$lib/openAi'
+import { DEFAULT_PROVIDER } from '$lib/provider'
 import type { Message, ToneType } from '$lib/types'
 import { fail } from '@sveltejs/kit'
 import type { Actions, PageServerLoad } from './$types'
@@ -15,7 +16,11 @@ export const load: PageServerLoad = async ({ url }) => {
     const start = new Date(end.getTime() - lookBack * ONE_HOUR)
     const { messages } = await queryMessagesDb(start.toISOString(), end.toISOString())
 
-    return { messages, multiProvider: !!KHOJ_API_URL }
+    return {
+        messages,
+        multiProvider: !!(KHOJ_API_URL && OPENAI_API_KEY),
+        defaultProvider: DEFAULT_PROVIDER,
+    }
 }
 
 export const actions: Actions = {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,11 +7,16 @@
     import ReplySuggestions from '$lib/components/ReplySuggestions.svelte'
     import ToneSelector from '$lib/components/ToneSelector.svelte'
     import { type Message, type PageData, TONES, type ToneType } from '$lib/types'
+    import type { ProviderConfig } from '$lib/providers/registry'
 
     const LOCAL_STORAGE_CONTEXT_KEY = 'wellsaid_additional_context'
 
     const { data } = $props<{
-        data: PageData & { multiProvider: boolean; defaultProvider: 'khoj' | 'openai' }
+        data: PageData & { 
+            multiProvider: boolean
+            defaultProvider: string
+            availableProviders: ProviderConfig[]
+        }
     }>()
 
     const DEFAULT_PROVIDER = data.defaultProvider
@@ -218,7 +223,7 @@
             </section>
             <hr />
             {#if data.multiProvider}
-                <AiProviderSelector bind:value={formState.ai.provider} />
+                <AiProviderSelector bind:value={formState.ai.provider} providers={data.availableProviders} />
             {/if}
         </form>
     </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,7 @@
     const LOCAL_STORAGE_CONTEXT_KEY = 'wellsaid_additional_context'
 
     const { data } = $props<{
-        data: PageData & { 
+        data: PageData & {
             multiProvider: boolean
             defaultProvider: string
             availableProviders: ProviderConfig[]
@@ -223,7 +223,10 @@
             </section>
             <hr />
             {#if data.multiProvider}
-                <AiProviderSelector bind:value={formState.ai.provider} providers={data.availableProviders} />
+                <AiProviderSelector
+                    bind:value={formState.ai.provider}
+                    providers={data.availableProviders}
+                />
             {/if}
         </form>
     </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,10 +8,13 @@
     import ToneSelector from '$lib/components/ToneSelector.svelte'
     import { type Message, type PageData, TONES, type ToneType } from '$lib/types'
 
-    const DEFAULT_PROVIDER = 'openai'
     const LOCAL_STORAGE_CONTEXT_KEY = 'wellsaid_additional_context'
 
-    const { data } = $props<{ data: PageData & { multiProvider: boolean } }>()
+    const { data } = $props<{
+        data: PageData & { multiProvider: boolean; defaultProvider: 'khoj' | 'openai' }
+    }>()
+
+    const DEFAULT_PROVIDER = data.defaultProvider
 
     let formState = $state({
         ai: {

--- a/tests/mocks/env-static-private.ts
+++ b/tests/mocks/env-static-private.ts
@@ -1,3 +1,6 @@
 export const JWT_SECRET = process.env.JWT_SECRET || ''
 export const APP_USERNAME = process.env.APP_USERNAME || ''
 export const APP_PASSWORD = process.env.APP_PASSWORD || ''
+export const KHOJ_API_URL = process.env.KHOJ_API_URL || ''
+export const OPENAI_API_KEY = process.env.OPENAI_API_KEY || ''
+export const DEFAULT_PROVIDER = process.env.DEFAULT_PROVIDER || ''

--- a/tests/routes/root/server.test.ts
+++ b/tests/routes/root/server.test.ts
@@ -62,6 +62,7 @@ describe('root page server', () => {
         expect(data).toEqual({
             messages: [{ text: 'hi', sender: 'partner', timestamp: '2025-01-01T00:00:00Z' }],
             multiProvider: false,
+            defaultProvider: 'openai',
         })
     })
 

--- a/tests/routes/root/server.test.ts
+++ b/tests/routes/root/server.test.ts
@@ -1,6 +1,7 @@
 import * as queryDb from '$lib/iMessages'
 import * as openai from '$lib/openAi'
 import * as khoj from '$lib/khoj'
+import * as registry from '$lib/providers/registry'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as serverModule from '../../../src/routes/+page.server'
 import type { RequestEvent } from '@sveltejs/kit'
@@ -8,6 +9,13 @@ import type { RequestEvent } from '@sveltejs/kit'
 vi.mock('$lib/iMessages', () => ({ queryMessagesDb: vi.fn() }))
 vi.mock('$lib/openAi', () => ({ getOpenaiReply: vi.fn() }))
 vi.mock('$lib/khoj', () => ({ getKhojReply: vi.fn() }))
+vi.mock('$lib/providers/registry', () => ({
+    getAvailableProviders: vi.fn(),
+    hasMultipleProviders: vi.fn(),
+}))
+vi.mock('$lib/provider', () => ({
+    DEFAULT_PROVIDER: 'openai',
+}))
 vi.mock('$lib/logger', () => ({
     logger: {
         error: vi.fn(),
@@ -49,6 +57,18 @@ function createMockRequestEvent(
 describe('root page server', () => {
     beforeEach(() => {
         vi.resetAllMocks()
+        
+        // Setup mocks for each test
+        vi.mocked(registry.getAvailableProviders).mockReturnValue([
+            {
+                id: 'openai',
+                name: 'OpenAI',
+                displayName: 'OpenAI (GPT)',
+                envVar: 'OPENAI_API_KEY',
+                isAvailable: true,
+            }
+        ])
+        vi.mocked(registry.hasMultipleProviders).mockReturnValue(false)
     })
 
     it('load should return messages and multiProvider flag', async () => {
@@ -63,6 +83,15 @@ describe('root page server', () => {
             messages: [{ text: 'hi', sender: 'partner', timestamp: '2025-01-01T00:00:00Z' }],
             multiProvider: false,
             defaultProvider: 'openai',
+            availableProviders: [
+                {
+                    id: 'openai',
+                    name: 'OpenAI',
+                    displayName: 'OpenAI (GPT)',
+                    envVar: 'OPENAI_API_KEY',
+                    isAvailable: true,
+                }
+            ],
         })
     })
 
@@ -181,8 +210,8 @@ describe('root page server', () => {
             isSubRequest: false,
         } as unknown as Parameters<typeof serverModule.actions.generate>[0])
 
-        expect(result.status).toBe(400)
-        expect(result.data.error).toBe(
+        expect((result as any).status).toBe(400)
+        expect((result as any).data.error).toBe(
             'Invalid messages format in FormData: Messages could not be parsed to an array.'
         )
     })

--- a/tests/routes/root/server.test.ts
+++ b/tests/routes/root/server.test.ts
@@ -1,10 +1,10 @@
 import * as queryDb from '$lib/iMessages'
-import * as openai from '$lib/openAi'
 import * as khoj from '$lib/khoj'
+import * as openai from '$lib/openAi'
 import * as registry from '$lib/providers/registry'
+import type { RequestEvent } from '@sveltejs/kit'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as serverModule from '../../../src/routes/+page.server'
-import type { RequestEvent } from '@sveltejs/kit'
 
 vi.mock('$lib/iMessages', () => ({ queryMessagesDb: vi.fn() }))
 vi.mock('$lib/openAi', () => ({ getOpenaiReply: vi.fn() }))
@@ -210,8 +210,8 @@ describe('root page server', () => {
             isSubRequest: false,
         } as unknown as Parameters<typeof serverModule.actions.generate>[0])
 
-        expect((result as any).status).toBe(400)
-        expect((result as any).data.error).toBe(
+        expect((result as { status: number }).status).toBe(400)
+        expect((result as { data: { error: string } }).data.error).toBe(
             'Invalid messages format in FormData: Messages could not be parsed to an array.'
         )
     })

--- a/tests/routes/root/server.test.ts
+++ b/tests/routes/root/server.test.ts
@@ -57,7 +57,7 @@ function createMockRequestEvent(
 describe('root page server', () => {
     beforeEach(() => {
         vi.resetAllMocks()
-        
+
         // Setup mocks for each test
         vi.mocked(registry.getAvailableProviders).mockReturnValue([
             {
@@ -66,7 +66,7 @@ describe('root page server', () => {
                 displayName: 'OpenAI (GPT)',
                 envVar: 'OPENAI_API_KEY',
                 isAvailable: true,
-            }
+            },
         ])
         vi.mocked(registry.hasMultipleProviders).mockReturnValue(false)
     })
@@ -90,7 +90,7 @@ describe('root page server', () => {
                     displayName: 'OpenAI (GPT)',
                     envVar: 'OPENAI_API_KEY',
                     isAvailable: true,
-                }
+                },
             ],
         })
     })


### PR DESCRIPTION
## Summary
- prefer Khoj as the default AI provider
- expose `defaultProvider` in server data
- pass provider from server to client page
- ensure at least one provider is configured on startup
- update tests for new default behavior

## Testing
- `yarn test`
- `yarn format`

------
https://chatgpt.com/codex/tasks/task_e_685467e3f7408320bde97dfa0f147eab