### PR TITLE
Add settings screen with sqlite-backed configuration

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1,4 +1,4 @@
-import { ANTHROPIC_API_KEY, ANTHROPIC_MODEL, ANTHROPIC_TEMPERATURE } from '$env/static/private'
+import { settings } from '$lib/config'
 import { anthropicPrompt } from '$lib/prompts'
 import type { Message, ToneType } from '$lib/types'
 import { extractReplies, parseSummaryToHumanReadable } from '$lib/utils'
@@ -10,9 +10,9 @@ const DEFAULT_MODEL = 'claude-3-opus-20240229'
 const DEFAULT_TEMPERATURE = 0.5
 
 const getConfig = () => ({
-    model: ANTHROPIC_MODEL || DEFAULT_MODEL,
-    temperature: Number(ANTHROPIC_TEMPERATURE || DEFAULT_TEMPERATURE),
-    apiKey: ANTHROPIC_API_KEY,
+    model: settings.ANTHROPIC_MODEL || DEFAULT_MODEL,
+    temperature: Number(settings.ANTHROPIC_TEMPERATURE || DEFAULT_TEMPERATURE),
+    apiKey: settings.ANTHROPIC_API_KEY,
 })
 
 export const getAnthropicReply = async (

--- a/src/lib/components/SettingsForm.svelte
+++ b/src/lib/components/SettingsForm.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+    import { enhance } from '$app/forms'
+    export let settings: { key: string; value: string; description: string }[]
+    export let action = '/settings?/save'
+</script>
+
+<form method="POST" use:enhance class="settings-form">
+    {#each settings as setting}
+        <div class="setting-row">
+            <label for={setting.key}>{setting.key}</label>
+            <input id={setting.key} name={setting.key} type="text" value={setting.value} />
+            <p class="description">{setting.description}</p>
+        </div>
+    {/each}
+    <button type="submit" formaction={action} class="save">Save</button>
+</form>
+
+<style>
+    .setting-row {
+        margin-bottom: 1rem;
+    }
+    label {
+        font-weight: bold;
+        display: block;
+    }
+    .description {
+        font-size: 0.8rem;
+        color: var(--gray);
+        margin-top: 0.25rem;
+    }
+    .save {
+        margin-top: 1rem;
+    }
+</style>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,71 @@
+import { env } from '$env/dynamic/private'
+import { open } from 'sqlite'
+import sqlite3 from 'sqlite3'
+import os from 'node:os'
+import path from 'node:path'
+
+export interface Setting {
+    key: string
+    value: string
+    description: string
+}
+
+const DB_PATH = path.join(os.homedir(), '.wellsaid_settings.db')
+
+const db = await open({ filename: DB_PATH, driver: sqlite3.Database })
+
+await db.exec(`CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT,
+    description TEXT
+)`)
+
+const defaultSettings: Record<string, { value?: string; description: string }> = {
+    PARTNER_PHONE: { value: env.PARTNER_PHONE, description: "Your partner's phone number in the Messages app" },
+    HISTORY_LOOKBACK_HOURS: { value: env.HISTORY_LOOKBACK_HOURS, description: 'How many hours of prior conversation history to search for extra context' },
+    CUSTOM_CONTEXT: { value: env.CUSTOM_CONTEXT, description: 'To guide the AI\'s personality and behavior (Example: "Act as my therapist suggesting replies to my partner" or "You are a helpful assistant")' },
+    OPENAI_API_KEY: { value: env.OPENAI_API_KEY, description: 'Your OpenAI API key' },
+    OPENAI_MODEL: { value: env.OPENAI_MODEL, description: 'gpt-4 or any other OpenAI model' },
+    OPENAI_TEMPERATURE: { value: env.OPENAI_TEMPERATURE, description: 'Controls the randomness of the responses' },
+    OPENAI_TOP_P: { value: env.OPENAI_TOP_P, description: 'Lets the responses be a little more adventurous' },
+    OPENAI_FREQUENCY_PENALTY: { value: env.OPENAI_FREQUENCY_PENALTY, description: 'Keeps the suggestions from repeating themselves' },
+    OPENAI_PRESENCE_PENALTY: { value: env.OPENAI_PRESENCE_PENALTY, description: 'Nudges the AI to bring up fresh ideas' },
+    ANTHROPIC_API_KEY: { value: env.ANTHROPIC_API_KEY, description: 'Your Anthropic API key' },
+    ANTHROPIC_MODEL: { value: env.ANTHROPIC_MODEL, description: 'claude-3-opus-20240229 or another Anthropic model' },
+    ANTHROPIC_TEMPERATURE: { value: env.ANTHROPIC_TEMPERATURE, description: "Controls the randomness of Claude's responses" },
+    GROK_API_KEY: { value: env.GROK_API_KEY, description: 'Your Grok API key' },
+    GROK_MODEL: { value: env.GROK_MODEL, description: 'grok-1 or another Grok model' },
+    GROK_TEMPERATURE: { value: env.GROK_TEMPERATURE, description: 'Controls the randomness of Grok\'s responses' },
+    KHOJ_API_URL: { value: env.KHOJ_API_URL, description: 'Your Khoj server API URL if you have one, otherwise leave this out or leave it blank' },
+    KHOJ_AGENT: { value: env.KHOJ_AGENT, description: 'optional specific agent to use' },
+}
+
+for (const [key, { value = '', description }] of Object.entries(defaultSettings)) {
+    await db.run(
+        'INSERT OR IGNORE INTO settings (key, value, description) VALUES (?, ?, ?)',
+        key,
+        value,
+        description
+    )
+}
+
+const rows = await db.all<Setting[]>('SELECT key, value, description FROM settings')
+
+export const settings: Record<string, string> = {}
+for (const row of rows) {
+    settings[row.key] = row.value
+}
+
+export async function updateSetting(key: string, value: string): Promise<void> {
+    await db.run(
+        'INSERT INTO settings (key, value, description) VALUES (?, ?, (SELECT description FROM settings WHERE key = ?)) ON CONFLICT(key) DO UPDATE SET value=excluded.value',
+        key,
+        value,
+        key
+    )
+    settings[key] = value
+}
+
+export async function getAllSettings(): Promise<Setting[]> {
+    return db.all<Setting[]>('SELECT key, value, description FROM settings')
+}

--- a/src/lib/grok.ts
+++ b/src/lib/grok.ts
@@ -1,4 +1,4 @@
-import { GROK_API_KEY, GROK_MODEL, GROK_TEMPERATURE } from '$env/static/private'
+import { settings } from '$lib/config'
 import { fetchRelevantHistory } from './history'
 import { logger } from './logger'
 import { openAiPrompt, systemContext } from './prompts'
@@ -10,9 +10,9 @@ const DEFAULT_MODEL = 'grok-1'
 const DEFAULT_TEMPERATURE = 0.5
 
 const getConfig = () => ({
-    model: GROK_MODEL || DEFAULT_MODEL,
-    temperature: Number(GROK_TEMPERATURE || DEFAULT_TEMPERATURE),
-    apiKey: GROK_API_KEY,
+    model: settings.GROK_MODEL || DEFAULT_MODEL,
+    temperature: Number(settings.GROK_TEMPERATURE || DEFAULT_TEMPERATURE),
+    apiKey: settings.GROK_API_KEY,
 })
 
 export const getGrokReply = async (
@@ -34,7 +34,7 @@ export const getGrokReply = async (
     const body = {
         model: config.model,
         messages: [
-            { role: 'system', content: systemContext },
+            { role: 'system', content: systemContext() },
             { role: 'user', content: formatMessagesAsText(messages) },
             { role: 'user', content: prompt },
         ],

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,13 +1,13 @@
-import { HISTORY_LOOKBACK_HOURS } from '$env/static/private'
+import { settings } from '$lib/config'
 import type { Message } from '$lib/types'
 import { queryMessagesDb } from './iMessages'
 import { logger } from './logger'
 import { formatMessagesAsText } from './utils'
 
-const lookbackHours = Number.parseInt(HISTORY_LOOKBACK_HOURS || '0')
 
 export const fetchRelevantHistory = async (messages: Message[]): Promise<string> => {
     try {
+        const lookbackHours = Number.parseInt(settings.HISTORY_LOOKBACK_HOURS || '0')
         if (!lookbackHours || messages.length === 0) {
             logger.warn('No messages or invalid lookbackHours; skipping history fetch')
             return ''

--- a/src/lib/iMessages.ts
+++ b/src/lib/iMessages.ts
@@ -1,4 +1,4 @@
-import { PARTNER_PHONE } from '$env/static/private'
+import { settings } from '$lib/config'
 import type { MessageRow } from '$lib/types'
 import os from 'node:os'
 import path from 'node:path'
@@ -11,7 +11,7 @@ const CHAT_DB_PATH = path.join(os.homedir(), 'Library', 'Messages', 'chat.db')
 
 const buildQuery = (startDate: string, endDate: string) => {
     logger.debug({ startDate, endDate }, 'Getting messages')
-    const params = [PARTNER_PHONE, isoToAppleNanoseconds(startDate), isoToAppleNanoseconds(endDate)]
+    const params = [settings.PARTNER_PHONE, isoToAppleNanoseconds(startDate), isoToAppleNanoseconds(endDate)]
 
     const query = `
         SELECT
@@ -35,7 +35,7 @@ const formatMessages = (rows: MessageRow[]) => {
         .map((row) => ({
             sender: row.is_from_me
                 ? 'me'
-                : row.contact_id === PARTNER_PHONE
+                : row.contact_id === settings.PARTNER_PHONE
                   ? 'partner'
                   : 'unknown',
             text: row.text,
@@ -47,8 +47,8 @@ const formatMessages = (rows: MessageRow[]) => {
 }
 
 export const queryMessagesDb = async (startDate: string, endDate: string) => {
-    if (!PARTNER_PHONE) {
-        logger.warn('PARTNER_PHONE env var not set -- make sure it is set in your .env file')
+    if (!settings.PARTNER_PHONE) {
+        logger.warn('PARTNER_PHONE setting not configured')
         return { messages: [] }
     }
 
@@ -57,7 +57,7 @@ export const queryMessagesDb = async (startDate: string, endDate: string) => {
 
     try {
         const rows = (await db.all(query, params)) as MessageRow[]
-        logger.info({ count: rows.length, handleId: PARTNER_PHONE }, 'Fetched messages')
+        logger.info({ count: rows.length, handleId: settings.PARTNER_PHONE }, 'Fetched messages')
 
         const formattedMessages = formatMessages(rows)
 

--- a/src/lib/khoj.ts
+++ b/src/lib/khoj.ts
@@ -1,11 +1,11 @@
-import { KHOJ_AGENT, KHOJ_API_URL } from '$env/static/private'
+import { settings } from '$lib/config'
 import { khojPrompt } from '$lib/prompts'
 import type { Message, ToneType } from '$lib/types'
 import { extractReplies, parseSummaryToHumanReadable } from '$lib/utils'
 import { fetchRelevantHistory } from './history'
 import { logger } from './logger'
 
-const khojApiUrl = KHOJ_API_URL || 'http://localhost:42110/api/chat'
+const khojApiUrl = settings.KHOJ_API_URL || 'http://localhost:42110/api/chat'
 
 export const getKhojReply = async (
     messages: Message[],
@@ -17,7 +17,7 @@ export const getKhojReply = async (
     const prompt = khojPrompt(messages, tone, mergedContext)
     const body = {
         q: prompt,
-        ...(KHOJ_AGENT ? { agent: KHOJ_AGENT } : {}),
+        ...(settings.KHOJ_AGENT ? { agent: settings.KHOJ_AGENT } : {}),
     }
 
     logger.debug({ body }, 'Khoj body')

--- a/src/lib/openAi.ts
+++ b/src/lib/openAi.ts
@@ -1,11 +1,4 @@
-import {
-    OPENAI_API_KEY,
-    OPENAI_FREQUENCY_PENALTY,
-    OPENAI_MODEL,
-    OPENAI_PRESENCE_PENALTY,
-    OPENAI_TEMPERATURE,
-    OPENAI_TOP_P,
-} from '$env/static/private'
+import { settings } from '$lib/config'
 import { fetchRelevantHistory } from './history'
 import { logger } from './logger'
 import { openAiPrompt, systemContext } from './prompts'
@@ -17,16 +10,16 @@ const DEFAULT_MODEL = 'gpt-4'
 const DEFAULT_TEMPERATURE = 0.5
 
 const getConfig = (): OpenAIConfig => ({
-    model: OPENAI_MODEL || DEFAULT_MODEL,
-    temperature: Number(OPENAI_TEMPERATURE || DEFAULT_TEMPERATURE),
-    topP: OPENAI_TOP_P ? Number(OPENAI_TOP_P) : undefined,
-    frequencyPenalty: OPENAI_FREQUENCY_PENALTY ? Number(OPENAI_FREQUENCY_PENALTY) : undefined,
-    presencePenalty: OPENAI_PRESENCE_PENALTY ? Number(OPENAI_PRESENCE_PENALTY) : undefined,
+    model: settings.OPENAI_MODEL || DEFAULT_MODEL,
+    temperature: Number(settings.OPENAI_TEMPERATURE || DEFAULT_TEMPERATURE),
+    topP: settings.OPENAI_TOP_P ? Number(settings.OPENAI_TOP_P) : undefined,
+    frequencyPenalty: settings.OPENAI_FREQUENCY_PENALTY ? Number(settings.OPENAI_FREQUENCY_PENALTY) : undefined,
+    presencePenalty: settings.OPENAI_PRESENCE_PENALTY ? Number(settings.OPENAI_PRESENCE_PENALTY) : undefined,
     apiUrl: API_URL,
-    apiKey: OPENAI_API_KEY,
+    apiKey: settings.OPENAI_API_KEY,
 })
 
-if (!OPENAI_API_KEY) {
+if (!settings.OPENAI_API_KEY) {
     logger.warn('⚠️ OPENAI_API_KEY is not set. OpenAI integration will not work.')
 }
 
@@ -72,7 +65,7 @@ export const getOpenaiReply = async (
     const body = {
         model: config.model,
         messages: [
-            { role: 'system', content: systemContext },
+            { role: 'system', content: systemContext() },
             { role: 'user', content: formatMessagesAsText(messages) },
             { role: 'user', content: prompt },
         ],

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,4 +1,4 @@
-import { CUSTOM_CONTEXT } from '$env/static/private'
+import { settings } from '$lib/config'
 import type { Message, ToneType } from './types'
 import { formatMessagesAsText } from './utils'
 
@@ -24,7 +24,7 @@ const responseFormat = [
     'Reply 3: <long reply>',
 ].join('\n')
 
-export const systemContext = [CUSTOM_CONTEXT, coreContext].join('\n\n')
+export const systemContext = () => [settings.CUSTOM_CONTEXT || '', coreContext].join('\n\n')
 
 const buildPrompt = (tone: string, context: string): string => {
     const lines = [`${instructions} ${tone}`]
@@ -36,7 +36,7 @@ export const openAiPrompt = (tone: string, context: string): string => buildProm
 
 export const khojPrompt = (messages: Message[], tone: ToneType, context: string): string =>
     [
-        systemContext,
+        systemContext(),
         'Here are some text messages between my partner and I:\n' + formatMessagesAsText(messages),
         buildPrompt(tone, context),
         responseFormat,
@@ -44,7 +44,7 @@ export const khojPrompt = (messages: Message[], tone: ToneType, context: string)
 
 export const anthropicPrompt = (messages: Message[], tone: ToneType, context: string): string =>
     [
-        systemContext,
+        systemContext(),
         'Here are some text messages between my partner and I:\n' + formatMessagesAsText(messages),
         buildPrompt(tone, context),
         responseFormat,

--- a/src/lib/providers/registry.ts
+++ b/src/lib/providers/registry.ts
@@ -1,4 +1,4 @@
-import { ANTHROPIC_API_KEY, KHOJ_API_URL, OPENAI_API_KEY, GROK_API_KEY } from '$env/static/private'
+import { settings } from '$lib/config'
 
 export interface ProviderConfig {
     id: string
@@ -43,23 +43,14 @@ const PROVIDER_REGISTRY: Omit<ProviderConfig, 'isAvailable'>[] = [
     // }
 ]
 
-// Environment variable lookup
-const ENV_VARS: Record<string, string | undefined> = {
-    OPENAI_API_KEY,
-    KHOJ_API_URL,
-    ANTHROPIC_API_KEY,
-    GROK_API_KEY,
-    // Add new env vars here as they become available
-    // GOOGLE_API_KEY
-}
 
 /**
- * Get all available AI providers based on configured environment variables
+ * Get all available AI providers based on configured settings
  */
 export function getAvailableProviders(): ProviderConfig[] {
     return PROVIDER_REGISTRY.map((provider) => ({
         ...provider,
-        isAvailable: !!ENV_VARS[provider.envVar],
+        isAvailable: !!settings[provider.envVar],
     })).filter((provider) => provider.isAvailable)
 }
 
@@ -71,7 +62,7 @@ export function getDefaultProvider(): string {
 
     if (available.length === 0) {
         throw new Error(
-            'No AI providers are configured. Please set at least one provider environment variable.'
+            'No AI providers are configured. Please set at least one provider in settings.'
         )
     }
 
@@ -95,7 +86,7 @@ export function validateProviders(): void {
 
     if (available.length === 0) {
         console.error(
-            'Error: No AI providers are configured. Set at least one of the following environment variables:'
+            'Error: No AI providers are configured. Set at least one of the following settings:'
         )
         PROVIDER_REGISTRY.forEach((provider) => {
             console.error(`  - ${provider.envVar} (for ${provider.displayName})`)

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -6,6 +6,7 @@ import { logger } from '$lib/logger'
 import { getOpenaiReply } from '$lib/openAi'
 import { DEFAULT_PROVIDER } from '$lib/provider'
 import { getAvailableProviders, hasMultipleProviders } from '$lib/providers/registry'
+import { getAllSettings } from '$lib/config'
 import type { Message, ToneType } from '$lib/types'
 import { fail } from '@sveltejs/kit'
 import type { Actions, PageServerLoad } from './$types'
@@ -17,12 +18,14 @@ export const load: PageServerLoad = async ({ url }) => {
     const end = new Date()
     const start = new Date(end.getTime() - lookBack * ONE_HOUR)
     const { messages } = await queryMessagesDb(start.toISOString(), end.toISOString())
+    const settings = await getAllSettings()
 
     return {
         messages,
         multiProvider: hasMultipleProviders(),
         defaultProvider: DEFAULT_PROVIDER,
         availableProviders: getAvailableProviders(),
+        settings,
     }
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,8 +6,10 @@
     import ControlBar from '$lib/components/ControlBar.svelte'
     import ReplySuggestions from '$lib/components/ReplySuggestions.svelte'
     import ToneSelector from '$lib/components/ToneSelector.svelte'
+    import SettingsForm from '$lib/components/SettingsForm.svelte'
     import { type Message, type PageData, TONES, type ToneType } from '$lib/types'
     import type { ProviderConfig } from '$lib/providers/registry'
+    import type { Setting } from '$lib/config'
 
     const LOCAL_STORAGE_CONTEXT_KEY = 'wellsaid_additional_context'
 
@@ -16,6 +18,7 @@
             multiProvider: boolean
             defaultProvider: string
             availableProviders: ProviderConfig[]
+            settings: Setting[]
         }
     }>()
 
@@ -37,6 +40,8 @@
             suggestedReplies: [] as string[],
         },
     })
+
+    let activeTab = $state<'main' | 'settings'>('main')
 
     let additionalContextExpanded = $state(false)
 
@@ -179,9 +184,24 @@
     <header>
         <h1>WellSaid</h1>
         <i>Empathy. Upgraded.</i>
+        <nav class="tab-bar">
+            <button
+                class:active={activeTab === 'main'}
+                on:click={() => (activeTab = 'main')}
+            >
+                home
+            </button>
+            <button
+                class:active={activeTab === 'settings'}
+                on:click={() => (activeTab = 'settings')}
+            >
+                settings
+            </button>
+        </nav>
     </header>
 
     <div class="content-container">
+        {#if activeTab === 'main'}
         <form onsubmit={handleSubmit}>
             <ControlBar
                 bind:lookBackHours={formState.form.lookBackHours}
@@ -229,6 +249,9 @@
                 />
             {/if}
         </form>
+        {:else}
+        <SettingsForm settings={data.settings} action="/settings?/save" />
+        {/if}
     </div>
 </main>
 
@@ -259,6 +282,7 @@
     /* ===== Header ===== */
     header {
         text-align: center;
+        position: relative;
     }
 
     header h1 {
@@ -274,6 +298,29 @@
         font-size: 1rem;
         display: block;
         margin-bottom: 1.25rem;
+    }
+
+    .tab-bar {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        display: flex;
+        gap: 0.5rem;
+    }
+
+    .tab-bar button {
+        font-size: 0.9rem;
+        background-color: var(--primary-dark);
+        color: var(--white);
+        padding: 0.25rem 0.5rem;
+        border-radius: var(--border-radius);
+        border: none;
+        cursor: pointer;
+        opacity: 0.6;
+    }
+
+    .tab-bar button.active {
+        opacity: 1;
     }
 
     /* ===== Conversation Section ===== */

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -1,0 +1,17 @@
+import { getAllSettings, updateSetting } from '$lib/config'
+import type { Actions, PageServerLoad } from './$types'
+
+export const load: PageServerLoad = async () => {
+    const settings = await getAllSettings()
+    return { settings }
+}
+
+export const actions: Actions = {
+    save: async ({ request }) => {
+        const data = await request.formData()
+        for (const [key, value] of data.entries()) {
+            await updateSetting(key, String(value))
+        }
+        return { success: true }
+    },
+}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+    import { enhance } from '$app/forms'
+    const { data } = $props<{ data: { settings: { key: string; value: string; description: string }[] } }>()
+</script>
+
+<svelte:head>
+    <title>Settings</title>
+</svelte:head>
+
+<main class="settings-page">
+    <h1>Settings</h1>
+    <form method="POST" use:enhance>
+        {#each data.settings as setting}
+            <div class="setting-row">
+                <label for={setting.key}>{setting.key}</label>
+                <input id={setting.key} name={setting.key} type="text" value={setting.value} />
+                <p class="description">{setting.description}</p>
+            </div>
+        {/each}
+        <button type="submit" formaction="?/save" class="save">Save</button>
+    </form>
+    <a href="/">Back</a>
+</main>
+
+<style>
+    .setting-row {
+        margin-bottom: 1rem;
+    }
+    label {
+        font-weight: bold;
+        display: block;
+    }
+    .description {
+        font-size: 0.8rem;
+        color: var(--gray);
+        margin-top: 0.25rem;
+    }
+    .save {
+        margin-top: 1rem;
+    }
+    a {
+        display: inline-block;
+        margin-top: 1rem;
+    }
+</style>

--- a/tests/lib/anthropic.test.ts
+++ b/tests/lib/anthropic.test.ts
@@ -10,16 +10,13 @@ vi.mock('$lib/prompts', () => ({
     anthropicPrompt: vi.fn().mockReturnValue('prompt'),
 }))
 
-vi.mock('$env/static/private', async (importOriginal) => {
-    const actual = (await importOriginal()) as Record<string, string | undefined>
-    return {
-        ...actual,
+vi.mock('$lib/config', () => ({
+    settings: {
         ANTHROPIC_API_KEY: 'test-api-key',
         ANTHROPIC_MODEL: 'test-model',
         ANTHROPIC_TEMPERATURE: '0.5',
-        LOG_LEVEL: 'info',
-    }
-})
+    },
+}))
 
 describe('getAnthropicReply', () => {
     beforeEach(() => {

--- a/tests/lib/grok.test.ts
+++ b/tests/lib/grok.test.ts
@@ -8,19 +8,16 @@ vi.mock('$lib/history', () => ({
 
 vi.mock('$lib/prompts', () => ({
     openAiPrompt: vi.fn().mockReturnValue('prompt'),
-    systemContext: 'sys',
+    systemContext: () => 'sys',
 }))
 
-vi.mock('$env/static/private', async (importOriginal) => {
-    const actual = (await importOriginal()) as Record<string, string | undefined>
-    return {
-        ...actual,
+vi.mock('$lib/config', () => ({
+    settings: {
         GROK_API_KEY: 'test-api-key',
         GROK_MODEL: 'test-model',
         GROK_TEMPERATURE: '0.5',
-        LOG_LEVEL: 'info',
-    }
-})
+    },
+}))
 
 describe('getGrokReply', () => {
     beforeEach(() => {

--- a/tests/lib/history.test.ts
+++ b/tests/lib/history.test.ts
@@ -6,9 +6,8 @@ vi.mock('$lib/iMessages', () => ({
     queryMessagesDb: vi.fn(),
 }))
 
-vi.mock('$env/static/private', () => ({
-    HISTORY_LOOKBACK_HOURS: '1',
-    LOG_LEVEL: 'info',
+vi.mock('$lib/config', () => ({
+    settings: { HISTORY_LOOKBACK_HOURS: '1' },
 }))
 
 const { queryMessagesDb } = await import('$lib/iMessages')

--- a/tests/lib/iMessages.test.ts
+++ b/tests/lib/iMessages.test.ts
@@ -18,9 +18,9 @@ vi.mock('$lib/logger', () => ({
     },
 }))
 
-// Mock the SvelteKit environment variables
-vi.mock('$env/static/private', () => ({
-    PARTNER_PHONE: '+1234567890',
+// Mock configuration settings
+vi.mock('$lib/config', () => ({
+    settings: { PARTNER_PHONE: '+1234567890' },
 }))
 
 describe('queryMessagesDb', () => {

--- a/tests/lib/khoj.test.ts
+++ b/tests/lib/khoj.test.ts
@@ -10,15 +10,12 @@ vi.mock('$lib/prompts', () => ({
     khojPrompt: vi.fn().mockReturnValue('prompt'),
 }))
 
-vi.mock('$env/static/private', async (importOriginal) => {
-    const actual = (await importOriginal()) as Record<string, string | undefined>
-    return {
-        ...actual,
+vi.mock('$lib/config', () => ({
+    settings: {
         KHOJ_API_URL: 'http://khoj.test/api',
         KHOJ_AGENT: '',
-        LOG_LEVEL: 'info',
-    }
-})
+    },
+}))
 
 describe('getKhojReply', () => {
     beforeEach(() => {

--- a/tests/lib/prompts.test.ts
+++ b/tests/lib/prompts.test.ts
@@ -2,16 +2,16 @@ import { khojPrompt, openAiPrompt, systemContext } from '$lib/prompts'
 import type { Message } from '$lib/types'
 import { describe, expect, it, vi } from 'vitest'
 
-// Mock the environment variable
-vi.mock('$env/static/private', () => ({
-    CUSTOM_CONTEXT: 'Test custom context for prompts',
+// Mock configuration setting
+vi.mock('$lib/config', () => ({
+    settings: { CUSTOM_CONTEXT: 'Test custom context for prompts' },
 }))
 
 describe('prompts', () => {
     describe('PERMANENT_CONTEXT', () => {
         it('should include custom context and instructions', () => {
-            expect(systemContext).toContain('Test custom context for prompts')
-            expect(systemContext).toContain('mimic my vocabulary and tone when suggesting replies')
+            expect(systemContext()).toContain('Test custom context for prompts')
+            expect(systemContext()).toContain('mimic my vocabulary and tone when suggesting replies')
         })
     })
 
@@ -61,7 +61,7 @@ describe('prompts', () => {
         it('should generate complete prompt with conversation and no context', () => {
             const result = khojPrompt(mockConversation, 'gentle', '')
 
-            expect(result).toContain(systemContext)
+            expect(result).toContain(systemContext())
             expect(result).toContain('Here are some text messages between my partner and I:')
             expect(result).toContain('me: Hey, how was your day?')
             expect(result).toContain('partner: It was great! How about yours?')
@@ -79,7 +79,7 @@ describe('prompts', () => {
             const context = 'They mentioned being stressed about work earlier'
             const result = khojPrompt(mockConversation, 'funny', context)
 
-            expect(result).toContain(systemContext)
+            expect(result).toContain(systemContext())
             expect(result).toContain('me: Hey, how was your day?')
             expect(result).toContain('Suggest 3 replies that I might send')
             expect(result).toContain('Extra context: ' + context)
@@ -93,7 +93,7 @@ describe('prompts', () => {
         it('should handle empty conversation', () => {
             const result = khojPrompt([], 'gentle', '')
 
-            expect(result).toContain(systemContext)
+            expect(result).toContain(systemContext())
             expect(result).toContain('Here are some text messages between my partner and I:')
             expect(result).toContain('Suggest 3 replies that I might send')
             expect(result).toContain('Summary:')

--- a/tests/mocks/env-dynamic-private.ts
+++ b/tests/mocks/env-dynamic-private.ts
@@ -1,0 +1,1 @@
+export const env: Record<string, string> = {}

--- a/tests/routes/root/server.test.ts
+++ b/tests/routes/root/server.test.ts
@@ -3,6 +3,7 @@ import * as khoj from '$lib/khoj'
 import * as openai from '$lib/openAi'
 import * as grok from '$lib/grok'
 import * as registry from '$lib/providers/registry'
+import * as config from '$lib/config'
 import type { RequestEvent } from '@sveltejs/kit'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as serverModule from '../../../src/routes/+page.server'
@@ -17,6 +18,9 @@ vi.mock('$lib/providers/registry', () => ({
 }))
 vi.mock('$lib/provider', () => ({
     DEFAULT_PROVIDER: 'openai',
+}))
+vi.mock('$lib/config', () => ({
+    getAllSettings: vi.fn(),
 }))
 vi.mock('$lib/logger', () => ({
     logger: {
@@ -71,6 +75,7 @@ describe('root page server', () => {
             },
         ])
         vi.mocked(registry.hasMultipleProviders).mockReturnValue(false)
+        vi.mocked(config.getAllSettings).mockResolvedValue([])
     })
 
     it('load should return messages and multiProvider flag', async () => {
@@ -94,6 +99,7 @@ describe('root page server', () => {
                     isAvailable: true,
                 },
             ],
+            settings: [],
         })
     })
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
         alias: {
             $lib: resolve('./src/lib'),
             '$env/static/private': resolve('./tests/mocks/env-static-private.ts'),
+            '$env/dynamic/private': resolve('./tests/mocks/env-dynamic-private.ts'),
         },
     },
     test: {


### PR DESCRIPTION
## Summary
- add tab-style settings panel alongside main conversation form
- fetch settings in root load and embed `SettingsForm` component
- include new `SettingsForm` component
- update tests for new data shape
- fix settings save action path

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_685997d5028c83209f285aeb8f76182e