### PR TITLE
Add provider registry tests

### DIFF
--- a/tests/lib/provider.test.ts
+++ b/tests/lib/provider.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('$lib/providers/registry', () => ({
+    getDefaultProvider: vi.fn(() => 'openai'),
+}))
+
+describe('provider module', () => {
+    it('exports the default provider when registry succeeds', async () => {
+        const mod = await import('$lib/provider')
+        expect(mod.DEFAULT_PROVIDER).toBe('openai')
+    })
+
+    it('sets null when registry throws', async () => {
+        vi.resetModules()
+        vi.doMock('$lib/providers/registry', () => ({
+            getDefaultProvider: vi.fn(() => {
+                throw new Error('no providers')
+            }),
+        }))
+
+        const mod = await import('$lib/provider')
+        expect(mod.DEFAULT_PROVIDER).toBeNull()
+    })
+})

--- a/tests/lib/providers/registry.test.ts
+++ b/tests/lib/providers/registry.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('$lib/config', () => ({ settings: {} }))
+
+// Helper to reload the module with fresh state
+async function loadRegistry() {
+    const mod = await import('$lib/providers/registry')
+    return mod
+}
+
+describe('provider registry', () => {
+    beforeEach(() => {
+        vi.resetModules()
+    })
+
+    it('returns only providers with configured settings', async () => {
+        const { settings } = await import('$lib/config')
+        settings.OPENAI_API_KEY = 'key'
+        settings.GROK_API_KEY = 'grok'
+        settings.KHOJ_API_URL = ''
+        settings.ANTHROPIC_API_KEY = ''
+
+        const { getAvailableProviders } = await loadRegistry()
+        const providers = getAvailableProviders()
+
+        expect(providers.map((p) => p.id)).toEqual(['openai', 'grok'])
+        expect(providers.every((p) => p.isAvailable)).toBe(true)
+    })
+
+    it('prefers khoj as default when available', async () => {
+        const { settings } = await import('$lib/config')
+        settings.KHOJ_API_URL = 'http://khoj.test'
+        settings.OPENAI_API_KEY = 'key'
+
+        const { getDefaultProvider } = await loadRegistry()
+        expect(getDefaultProvider()).toBe('khoj')
+    })
+
+    it('throws when no providers are configured', async () => {
+        const { settings } = await import('$lib/config')
+        Object.keys(settings).forEach((k) => delete (settings as any)[k])
+
+        const { getDefaultProvider } = await loadRegistry()
+        expect(() => getDefaultProvider()).toThrow(
+            'No AI providers are configured. Please set at least one provider in settings.'
+        )
+    })
+
+    it('detects multiple providers', async () => {
+        const { settings } = await import('$lib/config')
+        settings.OPENAI_API_KEY = 'key'
+        settings.ANTHROPIC_API_KEY = 'a'
+
+        const { hasMultipleProviders } = await loadRegistry()
+        expect(hasMultipleProviders()).toBe(true)
+    })
+})


### PR DESCRIPTION
## Summary
- cover `$lib/providers/registry` functions
- cover `$lib/provider` module

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685b5e4053c08320ae1b62ad2674a67e