### PR TITLE
Switch numeric fields to sliders

### DIFF
--- a/src/lib/components/SettingsForm.svelte
+++ b/src/lib/components/SettingsForm.svelte
@@ -8,7 +8,7 @@
 
     // Initialize form values from props
     let settingValues = $state<Record<string, string>>(
-        Object.fromEntries(settings.map(s => [s.key, s.value]))
+        Object.fromEntries(settings.map((s: { key: string; value: string }) => [s.key, s.value]))
     )
 
     const rangeSettings: Record<string, { min: number; max: number; step?: number }> = {
@@ -24,7 +24,7 @@
     // Update form values when settings change
     $effect(() => {
         if (form?.settings) {
-            settingValues = Object.fromEntries(form.settings.map(s => [s.key, s.value]));
+            settingValues = Object.fromEntries(form.settings.map((s: { key: string; value: string }) => [s.key, s.value]));
         }
     })
     

--- a/src/lib/components/SettingsForm.svelte
+++ b/src/lib/components/SettingsForm.svelte
@@ -266,6 +266,12 @@
         margin: 0;
     }
 
+    @media (max-width: 768px) {
+        input[type='range'] {
+            accent-color: var(--primary-dark);
+        }
+    }
+
     .range-value {
         display: inline-block;
         min-width: 30px;

--- a/src/lib/components/SettingsForm.svelte
+++ b/src/lib/components/SettingsForm.svelte
@@ -30,6 +30,17 @@
         }
     })
 
+    // Update local state when the form store returns fresh settings
+    $effect(() => {
+        if (form?.settings) {
+            const values: Record<string, string> = {}
+            for (const setting of form.settings) {
+                values[setting.key] = setting.value
+            }
+            settingValues = values
+        }
+    })
+
     // Group settings by provider
     const settingsGroups = $derived({
         general: settings.filter((s: { key: string; value: string; description: string }) =>

--- a/src/lib/components/SettingsForm.svelte
+++ b/src/lib/components/SettingsForm.svelte
@@ -19,25 +19,28 @@
         GROK_TEMPERATURE: { min: 0, max: 1, step: 0.1 },
     }
 
-    // Initialize form values once on mount
+    // Initialize and update form values when settings or form data changes
     $effect(() => {
-        if (Object.keys(settingValues).length === 0) {
-            const values: Record<string, string> = {}
-            for (const setting of settings) {
-                values[setting.key] = setting.value
+        // Always update from the latest settings or form data
+        const source = form?.settings || settings;
+        const values: Record<string, string> = {}
+        
+        // First, set all current values to preserve any user input
+        Object.assign(values, settingValues);
+        
+        // Then update with the latest settings from props or form
+        for (const setting of source) {
+            // Only update if the setting exists in the source but not in current values,
+            // or if it's different from the current value (but not empty)
+            if (!(setting.key in values) || 
+                (values[setting.key] === '' && setting.value !== '')) {
+                values[setting.key] = setting.value;
             }
-            settingValues = values
         }
-    })
-
-    // Update local state when the form store returns fresh settings
-    $effect(() => {
-        if (form?.settings) {
-            const values: Record<string, string> = {}
-            for (const setting of form.settings) {
-                values[setting.key] = setting.value
-            }
-            settingValues = values
+        
+        // Only update if there are actual changes to prevent infinite loops
+        if (JSON.stringify(settingValues) !== JSON.stringify(values)) {
+            settingValues = values;
         }
     })
 

--- a/src/lib/components/SettingsForm.svelte
+++ b/src/lib/components/SettingsForm.svelte
@@ -290,25 +290,35 @@
     }
 
     .save {
-        color: var(--primary-dark);
-        border: none;
-        border-radius: var(--border-radius);
         padding: 0.7rem 1.5rem;
-        font-size: 1rem;
-        font-weight: 600;
+        background-color: var(--primary-dark);
+        color: var(--white);
+        border: 1px solid var(--primary-light);
+        border-radius: var(--border-radius);
         cursor: pointer;
+        font-weight: 500;
         transition:
             background-color 0.2s,
             transform 0.1s;
+        min-height: var(--min-touch-size);
+        min-width: var(--min-touch-size);
+        display: flex;
+        align-items: center;
     }
 
     .save:hover {
-        background: var(--primary-dark);
-        color: var(--white);
+        background-color: var(--primary-dark);
     }
 
     .save:active {
-        transform: translateY(1px);
+        transform: scale(0.98);
+    }
+
+    .save:disabled {
+        background-color: var(--light);
+        color: var(--gray);
+        cursor: not-allowed;
+        border-color: var(--light);
     }
 
     .status-message {

--- a/src/lib/components/SettingsForm.svelte
+++ b/src/lib/components/SettingsForm.svelte
@@ -9,6 +9,16 @@
     // Simple reactive state for form values
     let settingValues = $state<Record<string, string>>({})
 
+    const rangeSettings: Record<string, { min: number; max: number; step?: number }> = {
+        HISTORY_LOOKBACK_HOURS: { min: 0, max: 48, step: 1 },
+        OPENAI_TEMPERATURE: { min: 0, max: 1, step: 0.1 },
+        OPENAI_TOP_P: { min: 0, max: 1, step: 0.05 },
+        OPENAI_FREQUENCY_PENALTY: { min: -2, max: 2, step: 0.1 },
+        OPENAI_PRESENCE_PENALTY: { min: -2, max: 2, step: 0.1 },
+        ANTHROPIC_TEMPERATURE: { min: 0, max: 1, step: 0.1 },
+        GROK_TEMPERATURE: { min: 0, max: 1, step: 0.1 },
+    }
+
     // Initialize form values once on mount
     $effect(() => {
         if (Object.keys(settingValues).length === 0) {
@@ -106,6 +116,20 @@
                                     rows="4"
                                     class="context-textarea"
                                 ></textarea>
+                            {:else if rangeSettings[setting.key]}
+                                <div class="range-wrapper">
+                                    <input
+                                        id={setting.key}
+                                        name={setting.key}
+                                        type="range"
+                                        min={rangeSettings[setting.key].min}
+                                        max={rangeSettings[setting.key].max}
+                                        step={rangeSettings[setting.key].step ?? 1}
+                                        bind:value={settingValues[setting.key]}
+                                        class="range-input"
+                                    />
+                                    <span class="range-value">{settingValues[setting.key]}</span>
+                                </div>
                             {:else}
                                 <input
                                     id={setting.key}
@@ -210,13 +234,28 @@
         width: 200px;
     }
 
-    input[name='HISTORY_LOOKBACK_HOURS'],
-    input[id$='_TEMPERATURE'],
-    input[id$='_TOP_P'],
-    input[id$='_PENALTY'] {
+    input[type='text'][name='HISTORY_LOOKBACK_HOURS'],
+    input[type='text'][id$='_TEMPERATURE'],
+    input[type='text'][id$='_TOP_P'],
+    input[type='text'][id$='_PENALTY'] {
         width: 70px;
         text-align: center;
         padding: 0.6rem 0.5rem;
+    }
+
+    .range-wrapper {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    .range-input {
+        width: 200px;
+    }
+
+    .range-value {
+        width: 40px;
+        text-align: center;
     }
 
     input[name='OPENAI_MODEL'],

--- a/src/lib/components/SettingsForm.svelte
+++ b/src/lib/components/SettingsForm.svelte
@@ -24,16 +24,18 @@
     // Update form values when settings change
     $effect(() => {
         if (form?.settings) {
-            settingValues = Object.fromEntries(form.settings.map((s: { key: string; value: string }) => [s.key, s.value]));
+            settingValues = Object.fromEntries(
+                form.settings.map((s: { key: string; value: string }) => [s.key, s.value])
+            )
         }
     })
-    
+
     // Handle range input changes
     function handleRangeChange(key: string, value: string) {
-        const num = parseFloat(value);
-        const range = rangeSettings[key];
+        const num = parseFloat(value)
+        const range = rangeSettings[key]
         if (!isNaN(num) && num >= range.min && num <= range.max) {
-            settingValues = { ...settingValues, [key]: value };
+            settingValues = { ...settingValues, [key]: value }
         }
     }
 
@@ -260,6 +262,8 @@
 
     .range-input {
         width: 200px;
+        padding: 8px 0;
+        margin: 0;
     }
 
     .range-value {
@@ -267,7 +271,7 @@
         min-width: 30px;
         text-align: center;
         font-family: monospace;
-        font-size: 0.9em;
+        font-size: 1.3em;
         margin-left: 10px;
         color: var(--text);
     }


### PR DESCRIPTION
## Summary
- add slider config for numeric settings
- show range sliders in settings form
- tweak form styles for range controls

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685ee5048e6c8320be769bd7004d4a54